### PR TITLE
Remove unnecessary coordinate attributes

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Remove unnecessary coordinate attributes (:pr:`23`)
 * Disable navigation sidebars (:pr:`19`)
 * Add Github Issue and PR templates (:pr:`17`)
 * Improve key resolution (:pr:`15`)

--- a/xarray_ms/backend/msv2/antenna_dataset_factory.py
+++ b/xarray_ms/backend/msv2/antenna_dataset_factory.py
@@ -26,11 +26,13 @@ class AntennaDatasetFactory:
       },
       coords={
         "antenna_name": Variable("antenna_name", ants["NAME"].to_numpy()),
-        "station": Variable(
-          "antenna_name", ants["STATION"].to_numpy(), {"coordinates": "station"}
-        ),
         "mount": Variable(
-          "antenna_name", ants["MOUNT"].to_numpy(), {"coordinates": "mount"}
+          "antenna_name",
+          ants["MOUNT"].to_numpy(),
+        ),
+        "station": Variable(
+          "antenna_name",
+          ants["STATION"].to_numpy(),
         ),
       },
     )


### PR DESCRIPTION
Coordinate attributes are only necessary in `AbstractVariableStore.get_variables`, not in the `Dataset` constructor.

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--23.org.readthedocs.build/en/23/

<!-- readthedocs-preview xarray-ms end -->