### PR TITLE
Fix changelog highlighting in install documentation

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Fix changelog hightlighting in install instructions (:pr:`33`)
 * Add basic read tests (:pr:`32`)
 * Fix Dataset and DataTree equivalence checks in test cases (:pr:`31`)
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -76,7 +76,7 @@ Release Process
 For a new version number, say ``0.2.0``, perform the following operations
 on the ``main`` branch:
 
-1. Edit `doc/source/changelog.rst` to reflect the new version.
+1. Edit ``doc/source/changelog.rst`` to reflect the new version.
 2. Run
 
    .. code-block:: bash


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [ ] Test Cases covering your PR.
- [x] Documentation.
- [ ] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--33.org.readthedocs.build/en/33/

<!-- readthedocs-preview xarray-ms end -->