### PR TITLE
Pin xarray to 2024.9.0

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Allow arcae to vary in the 0.2.x range (:pr:`42`)
+* Pin xarray to 2024.9.0 (:pr:`42`)
 * Add test case for irregular grids (:pr:`39`, :pr:`40`, :pr:`41`)
 * Rename MSv2PartitionEntryPoint to MSv2EntryPoint (:pr:`38`)
 * Move ``chunks`` kwarg functionality in MSv2PartitionEntryPoint.open_datatree

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.rst"
 [tool.poetry.dependencies]
 python = "^3.10"
 pytest = {version = "^8.0.0", optional = true, extras = ["testing"]}
-xarray = "^2024.3.0"
+xarray = "^2024.9.0, < 2024.10.0"
 dask = {version = "^2024.5.0", optional = true, extras = ["testing"]}
 distributed = {version = "^2024.5.0", optional = true, extras = ["testing"]}
 cacheout = "^0.16.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ xarray = "^2024.9.0, < 2024.10.0"
 dask = {version = "^2024.5.0", optional = true, extras = ["testing"]}
 distributed = {version = "^2024.5.0", optional = true, extras = ["testing"]}
 cacheout = "^0.16.0"
-arcae = "^0.2.5"
+arcae = "^0.2"
 typing-extensions = { version = "^4.12.2", python = "<3.11" }
 zarr = {version = "^2.18.3", optional = true, extras = ["testing"]}
 


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

xarray 2024.10.0 expanded the chunk handling for DataTree's.

- https://github.com/pydata/xarray/pull/9660

This broke the custom chunking logic built around  the `partition_chunks` kwarg 

 - https://github.com/ratt-ru/xarray-ms/pull/37

This PR pins xarray to 2024.9.0 in anticipation of a cleaner implementation:

- https://github.com/pydata/xarray/issues/9634

and also allows arcae version to vary in the 0.2.x range

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.
