### PR TITLE
Skip segfaulting test_lexical_binary_search test case

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Skip test case that segfaults on numpy 2.2.2 (:pr:`50`)
 * Upgrade to xarray 2025.1.1 (:pr:`49`)
 * Add documentation link to MSv2EntryPoint class (:pr:`47`)
 * Change visibility partition structure to ``msname/partition-001`` (:pr:`46`)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,6 +3,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 
+@pytest.mark.skip(reason="https://github.com/numpy/numpy/issues/28190")
 @pytest.mark.parametrize("na", [7])
 def test_lexical_binary_search(na):
   rng = np.random.default_rng(seed=42)


### PR DESCRIPTION
- Related numpy issue https://github.com/numpy/numpy/issues/28190

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.
