### PR TITLE
Fix open_datatree call in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,9 +22,9 @@ to be developed on well-understood MSv2 data.
 .. code-block:: python
 
   >>> import xarray_ms
-  >>> from xarray.backends.api import datatree
-  >>> dt = open_datatree("/data/L795830_SB001_uv.MS/",
-                         preferred_chunks={"time": 2000, "baseline_id": 1000})
+  >>> import xarray
+  >>> dt = xarray.open_datatree("/data/L795830_SB001_uv.MS/",
+                                preferred_chunks={"time": 2000, "baseline_id": 1000})
   >>> dt
   <xarray.DataTree>
   Group: /

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Fix `open_datatree` instructions in the README (:pr:`51`)
 * Skip test case that segfaults on numpy 2.2.2 (:pr:`50`)
 * Upgrade to xarray 2025.1.1 (:pr:`49`)
 * Add documentation link to MSv2EntryPoint class (:pr:`47`)


### PR DESCRIPTION

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--51.org.readthedocs.build/en/51/

<!-- readthedocs-preview xarray-ms end -->