### PR TITLE
Use np.logical_or.reduce for generating diffs over more than 2 partitioning arrays

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Use np.logical_or.reduce for generating diffs over more than 2 partitioning arrays
 * Improve Missing Column error (:pr:`52`)
 * Fix `open_datatree` instructions in the README (:pr:`51`)
 * Skip test case that segfaults on numpy 2.2.2 (:pr:`50`)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -118,7 +118,9 @@ def test_open_dataset(simmed_ms):
   ],
   ids=id_string,
 )
-@pytest.mark.parametrize("partition_columns", [["DATA_DESC_ID", "FIELD_ID"]])
+@pytest.mark.parametrize(
+  "partition_columns", [["DATA_DESC_ID", "OBSERVATION_ID", "FIELD_ID"]]
+)
 def test_open_dataset_partition_keys(
   simmed_ms, partition_columns, partition_key, pols, nfreq
 ):

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -195,7 +195,7 @@ class TablePartitioner:
     # Find the group start and end points in parallel
     def find_edges(p, s):
       diffs = [np.diff(p[v]) > 0 for v in self._partitionby]
-      return np.where(np.logical_or(*diffs))[0] + s + 1
+      return np.where(np.logical_or.reduce(diffs))[0] + s + 1
 
     group_diffs = [
       {k: v[s : s + chunk + 1] for k, v in merged.items() if k in self._partitionby}


### PR DESCRIPTION

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--53.org.readthedocs.build/en/53/

<!-- readthedocs-preview xarray-ms end -->