### PR TITLE
Further align partitioning code with MSv4

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -13,10 +13,10 @@ be used to open either a :class:`~xarray.Dataset` or a
 
     >>> dataset = xarray.open_dataset(
                     "/data/data.ms",
-                    partition_columns=["DATA_DESC_ID", "FIELD_ID"])
+                    partition_schema=["DATA_DESC_ID", "FIELD_ID"])
     >>> datatree = xarray.backends.api.open_datatree(
                     "/data/data.ms",
-                    partition_columns=["DATA_DESC_ID", "FIELD_ID"])
+                    partition_schema=["DATA_DESC_ID", "FIELD_ID"])
 
 These methods defer to the relevant methods on the
 `Entrypoint Class <entrypoint-class_>`_.

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -33,3 +33,22 @@ Entrypoint class for the MSv2 backend.
 
 .. autoclass:: xarray_ms.backend.msv2.entrypoint.MSv2EntryPoint
     :members: open_dataset, open_datatree
+
+.. _partitioning-schema:
+
+Partioning Schema
+-----------------
+
+The default partitioning schema contains the following columns:
+
+.. autodata:: xarray_ms.backend.msv2.structure.DEFAULT_PARTITION_COLUMNS
+
+Partitioning always uses these columns, but additional columns can be
+selected if finer grained partitioning is required:
+
+.. autodata:: xarray_ms.backend.msv2.structure.VALID_PARTITION_COLUMNS
+
+Note that ``OBS_MODE`` and ``SUB_SCAN_NUMBER`` are columns in the ``STATE``
+subtable, while ``SOURCE_ID`` is a column of the ``FIELD`` subtable.
+Partitioning on these columns is achieved by joining on the ``STATE_ID``
+and ``FIELD_ID`` columns, respectively.

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Further partitioning improvement and alignment with MSv4 (:pr:`55`)
 * Use epoch to dintinguish multiple instances of the same dataset (:pr:`54`)
 * Use np.logical_or.reduce for generating diffs over more than 2 partitioning arrays (:pr:`53`)
 * Improve Missing Column error (:pr:`52`)

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -13,10 +13,10 @@ collection of Datasets of ndarrays on a regular grid.
 To move data between the two formats, it is necessary to partition
 or group MSv2 rows by the same shape and configuration.
 
-In xarray-ms, this is accomplished by specifying ``partition_columns``
+In xarray-ms, this is accomplished by specifying ``partition_schema``
 when opening a Measurement Set.
-Different columns may be used to define the partition, but
-:code:`[DATA_DESC_ID, FIELD_ID, OBSERVATION_ID]` is a reasonable choice.
+Different columns may be used to define the partition.
+:code:`[DATA_DESC_ID, OBS_MODE, OBSERVATION_ID]` is the default.
 
 Opening a Measurement Set
 -------------------------
@@ -39,7 +39,7 @@ to open multiple partitions of a Measurement Set.
     (8, ("XX", "XY", "YX", "YY")),
     (4, ("RR", "LL"))])
 
-  dt = open_datatree(ms, partition_columns=[
+  dt = open_datatree(ms, partition_schema=[
       "DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"])
 
   dt
@@ -62,7 +62,7 @@ For example, one could select select some specific dimensions out:
 .. ipython:: python
 
   dt = open_datatree(ms,
-    partition_columns=["DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"])
+    partition_schema=["DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"])
 
   subdt = dt.isel(time=slice(1, 3), baseline_id=[1, 3, 5], frequency=slice(2, 4))
   subdt
@@ -92,7 +92,7 @@ can be enabled by specifying the ``chunks`` parameter:
 
 .. ipython:: python
 
-  dt = open_datatree(ms, partition_columns=[
+  dt = open_datatree(ms, partition_schema=[
     "DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"],
     chunks={"time": 2, "frequency": 2})
 
@@ -108,7 +108,7 @@ to specify different chunking setups for each partition.
 
 .. ipython:: python
 
-  dt = open_datatree(ms, partition_columns=[
+  dt = open_datatree(ms, partition_schema=[
     "DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"],
     chunks={},
     preferred_chunks={
@@ -137,7 +137,7 @@ this to a zarr_ store.
   import os.path
   import tempfile
 
-  dt = open_datatree(ms, partition_columns=[
+  dt = open_datatree(ms, partition_schema=[
     "DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"],
     chunks={},
     preferred_chunks={

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -16,7 +16,7 @@ or group MSv2 rows by the same shape and configuration.
 In xarray-ms, this is accomplished by specifying ``partition_schema``
 when opening a Measurement Set.
 Different columns may be used to define the partition.
-:code:`[DATA_DESC_ID, OBS_MODE, OBSERVATION_ID]` is the default.
+See :ref:`partitioning-schema` for more information.
 
 Opening a Measurement Set
 -------------------------
@@ -32,15 +32,13 @@ to open multiple partitions of a Measurement Set.
   import xarray
   import xarray.testing
   from xarray_ms.testing.simulator import simulate
-  from xarray.backends.api import open_datatree
 
   # Simulate a Measurement Set with 2 channel and polarisation configurations
   ms = simulate("test.ms", data_description=[
     (8, ("XX", "XY", "YX", "YY")),
     (4, ("RR", "LL"))])
 
-  dt = open_datatree(ms, partition_schema=[
-      "DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"])
+  dt = xarray.open_datatree(ms, partition_schema=["FIELD_ID"])
 
   dt
 
@@ -61,8 +59,7 @@ For example, one could select select some specific dimensions out:
 
 .. ipython:: python
 
-  dt = open_datatree(ms,
-    partition_schema=["DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"])
+  dt = xarray.open_datatree(ms, partition_schema=["FIELD_ID"])
 
   subdt = dt.isel(time=slice(1, 3), baseline_id=[1, 3, 5], frequency=slice(2, 4))
   subdt
@@ -92,8 +89,7 @@ can be enabled by specifying the ``chunks`` parameter:
 
 .. ipython:: python
 
-  dt = open_datatree(ms, partition_schema=[
-    "DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"],
+  dt = xarray.open_datatree(ms, partition_schema=["FIELD_ID"],
     chunks={"time": 2, "frequency": 2})
 
   dt
@@ -108,8 +104,7 @@ to specify different chunking setups for each partition.
 
 .. ipython:: python
 
-  dt = open_datatree(ms, partition_schema=[
-    "DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"],
+  dt = xarray.open_datatree(ms, partition_schema=["FIELD_ID"],
     chunks={},
     preferred_chunks={
       (("DATA_DESC_ID", 0),): {"time": 2, "frequency": 4},
@@ -137,8 +132,7 @@ this to a zarr_ store.
   import os.path
   import tempfile
 
-  dt = open_datatree(ms, partition_schema=[
-    "DATA_DESC_ID", "FIELD_ID", "OBSERVATION_ID"],
+  dt = xarray.open_datatree(ms, partition_schema=["FIELD_ID"],
     chunks={},
     preferred_chunks={
       (("DATA_DESC_ID", 0),): {"time": 2, "frequency": 4},
@@ -151,7 +145,7 @@ It is then trivial to open this using ``open_datatree``:
 
 .. ipython:: python
 
-  dt2 = open_datatree(zarr_path)
+  dt2 = xarray.open_datatree(zarr_path)
   xarray.testing.assert_identical(dt, dt2)
 
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -24,13 +24,14 @@ def test_baseline_id(na, auto_corrs):
 
 
 @pytest.mark.parametrize("simmed_ms", [{"name": "proxy.ms"}], indirect=True)
-def test_structure_factory(simmed_ms):
+@pytest.mark.parametrize("epoch", ["abcdcefg"])
+def test_structure_factory(simmed_ms, epoch):
   partition_columns = ["FIELD_ID", "DATA_DESC_ID", "OBSERVATION_ID"]
   table_factory = TableFactory(Table.from_filename, simmed_ms)
-  structure_factory = MSv2StructureFactory(table_factory, partition_columns)
+  structure_factory = MSv2StructureFactory(table_factory, partition_columns, epoch)
   assert pickle.loads(pickle.dumps(structure_factory)) == structure_factory
 
-  structure_factory2 = MSv2StructureFactory(table_factory, partition_columns)
+  structure_factory2 = MSv2StructureFactory(table_factory, partition_columns, epoch)
   assert structure_factory() is structure_factory2()
 
   keys = tuple(k for kv in structure_factory().keys() for k, _ in kv)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -60,24 +60,32 @@ def test_table_partitioner():
     groups,
     {
       (("DATA_DESC_ID", 0), ("FIELD_ID", 0)): {
+        "DATA_DESC_ID": [0, 0],
+        "FIELD_ID": [0, 0],
         "TIME": [2.0, 4.0],
         "ANTENNA1": [0, 0],
         "ANTENNA2": [1, 1],
         "row": [4, 2],
       },
       (("DATA_DESC_ID", 0), ("FIELD_ID", 1)): {
+        "DATA_DESC_ID": [0],
+        "FIELD_ID": [1],
         "TIME": [3.0],
         "ANTENNA1": [0],
         "ANTENNA2": [1],
         "row": [3],
       },
       (("DATA_DESC_ID", 1), ("FIELD_ID", 0)): {
+        "DATA_DESC_ID": [1],
+        "FIELD_ID": [0],
         "TIME": [1.0],
         "ANTENNA1": [0],
         "ANTENNA2": [1],
         "row": [1],
       },
       (("DATA_DESC_ID", 1), ("FIELD_ID", 1)): {
+        "DATA_DESC_ID": [1],
+        "FIELD_ID": [1],
         "TIME": [0.0],
         "ANTENNA1": [0],
         "ANTENNA2": [1],

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -26,16 +26,16 @@ def test_baseline_id(na, auto_corrs):
 @pytest.mark.parametrize("simmed_ms", [{"name": "proxy.ms"}], indirect=True)
 @pytest.mark.parametrize("epoch", ["abcdef"])
 def test_structure_factory(simmed_ms, epoch):
-  partition_columns = ["FIELD_ID", "DATA_DESC_ID", "OBSERVATION_ID"]
+  partition_schema = ["FIELD_ID", "DATA_DESC_ID", "OBSERVATION_ID", "OBS_MODE"]
   table_factory = TableFactory(Table.from_filename, simmed_ms)
-  structure_factory = MSv2StructureFactory(table_factory, partition_columns, epoch)
+  structure_factory = MSv2StructureFactory(table_factory, partition_schema, epoch)
   assert pickle.loads(pickle.dumps(structure_factory)) == structure_factory
 
-  structure_factory2 = MSv2StructureFactory(table_factory, partition_columns, epoch)
+  structure_factory2 = MSv2StructureFactory(table_factory, partition_schema, epoch)
   assert structure_factory() is structure_factory2()
 
   keys = tuple(k for kv in structure_factory().keys() for k, _ in kv)
-  assert tuple(sorted(partition_columns)) == keys
+  assert tuple(sorted(partition_schema)) == keys
 
 
 def test_table_partitioner():
@@ -96,13 +96,13 @@ def test_table_partitioner():
 
 
 def test_epoch(simmed_ms):
-  partition_columns = ["FIELD_ID", "DATA_DESC_ID", "OBSERVATION_ID"]
+  partition_schema = ["FIELD_ID", "DATA_DESC_ID", "OBSERVATION_ID"]
   table_factory = TableFactory(Table.from_filename, simmed_ms)
-  structure_factory = MSv2StructureFactory(table_factory, partition_columns, "abc")
-  structure_factory2 = MSv2StructureFactory(table_factory, partition_columns, "abc")
+  structure_factory = MSv2StructureFactory(table_factory, partition_schema, "abc")
+  structure_factory2 = MSv2StructureFactory(table_factory, partition_schema, "abc")
 
   assert structure_factory() is structure_factory2()
 
-  structure_factory3 = MSv2StructureFactory(table_factory, partition_columns, "def")
+  structure_factory3 = MSv2StructureFactory(table_factory, partition_schema, "def")
 
   assert structure_factory() is not structure_factory3()

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -92,7 +92,7 @@ def initialise_default_args(
   epoch = epoch or uuid4().hex[:8]
   partition_columns = partition_columns or DEFAULT_PARTITION_COLUMNS
   structure_factory = structure_factory or MSv2StructureFactory(
-    table_factory, partition_columns, auto_corrs=auto_corrs
+    table_factory, partition_columns, epoch, auto_corrs=auto_corrs
   )
   return epoch, table_factory, partition_columns, structure_factory
 

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -223,7 +223,7 @@ class MSv2Store(AbstractWritableDataStore):
       "xarray_ms_version": importlib_version("xarray-ms"),
     }
 
-    return {**attrs, **factory.get_attrs()}
+    return dict(sorted({**attrs, **factory.get_attrs()}.items()))
 
   def get_dimensions(self):
     return None
@@ -367,8 +367,8 @@ class MSv2EntryPoint(BackendEntrypoint):
         Defaults to :code:`{DEFAULT_PARTITION_COLUMNS}`.
       auto_corrs: Include/Exclude auto-correlations.
       ninstances: The number of Measurement Set instances to open for parallel I/O.
-      epoch: A unique string identifying the creation of this Dataset.
-        This should not normally need to be set by the user
+      epoch: A string uniquely identifying this Dataset.
+        This should not normally be set by the user
 
     Returns:
       An xarray :class:`~xarray.core.datatree.DataTree`

--- a/xarray_ms/backend/msv2/main_dataset_factory.py
+++ b/xarray_ms/backend/msv2/main_dataset_factory.py
@@ -231,3 +231,21 @@ class MainDatasetFactory:
     )
 
     return FrozenDict(sorted(data_vars + coordinates))
+
+  def _partition_info(self) -> Dict[Any, Any]:
+    structure = self._structure_factory()
+    partition = structure[self._partition_key]
+
+    return {
+      "spectal_window_name": partition.spw_name,
+      "field_name": list(set(partition.field_names)),
+      "polarization_setup": partition.corr_type,
+      "scan_number": list(set(partition.scan_numbers)),
+      "sub_scan_number": list(set(partition.sub_scan_numbers)),
+      "source_name": list(set(partition.source_names)),
+      "line_name": list(map(list, set(map(tuple, partition.line_names)))),
+      "intent": list(set(partition.intents)),
+    }
+
+  def get_attrs(self) -> Dict[Any, Any]:
+    return {"partition_info": self._partition_info()}

--- a/xarray_ms/backend/msv2/main_dataset_factory.py
+++ b/xarray_ms/backend/msv2/main_dataset_factory.py
@@ -236,16 +236,20 @@ class MainDatasetFactory:
     structure = self._structure_factory()
     partition = structure[self._partition_key]
 
-    return {
-      "spectal_window_name": partition.spw_name,
-      "field_name": list(set(partition.field_names)),
-      "polarization_setup": partition.corr_type,
-      "scan_number": list(set(partition.scan_numbers)),
-      "sub_scan_number": list(set(partition.sub_scan_numbers)),
-      "source_name": list(set(partition.source_names)),
-      "line_name": list(map(list, set(map(tuple, partition.line_names)))),
-      "intent": list(set(partition.intents)),
-    }
+    return dict(
+      sorted(
+        {
+          "spectal_window_name": partition.spw_name,
+          "field_name": list(set(partition.field_names)),
+          "polarization_setup": partition.corr_type,
+          "scan_number": list(set(partition.scan_numbers)),
+          "sub_scan_number": list(set(partition.sub_scan_numbers)),
+          "source_name": list(set(partition.source_names)),
+          "line_name": list(map(list, set(map(tuple, partition.line_names)))),
+          "intent": list(set(partition.intents)),
+        }.items()
+      )
+    )
 
   def get_attrs(self) -> Dict[Any, Any]:
     return {"partition_info": self._partition_info()}

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -607,8 +607,6 @@ class MSv2Structure(Mapping):
         source_names = sources["NAME"].to_pylist()
         if "TRANSITION" in self._source.column_names:
           line_names = sources["TRANSITION"].to_pylist()
-          # import pyarrow.compute as pac
-          # line_names = pac.list_flatten(sources["TRANSITION"]).to_pylist()
 
     # Extract scan numbers
     scan_number = value.get("SCAN_NUMBER")

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -113,7 +113,7 @@ DEFAULT_PARTITION_COLUMNS: List[str] = [
   "DATA_DESC_ID",
   "OBS_MODE",
   "OBSERVATION_ID",
-]
+]  #: Default Partitioning Column Schema
 
 
 SHORT_TO_LONG_PARTITION_COLUMNS: Dict[str, str] = {
@@ -145,6 +145,7 @@ VALID_STATE_PARTITION_COLUMNS: List[str] = [
   "SUB_SCAN_NUMBER",
 ]
 
+#: Valid partitioning columns
 VALID_PARTITION_COLUMNS: List[str] = (
   VALID_MAIN_PARTITION_COLUMNS
   + VALID_FIELD_PARTITION_COLUMNS

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -335,7 +335,7 @@ class MSv2Structure(Mapping):
 
   _ms_factory: TableFactory
   _auto_corrs: bool
-  _partition_schema: List[str]
+  _partition_columns: List[str]
   _partitions: Mapping[PartitionKeyT, PartitionData]
   _column_descs: Dict[str, Dict[str, ColumnDesc]]
   _ant: pa.Table
@@ -407,7 +407,7 @@ class MSv2Structure(Mapping):
     if isinstance(key, str):
       key = self.parse_partition_key(key)
 
-    column_set = set(self._partition_schema)
+    column_set = set(self._partition_columns)
 
     # Check that the key columns and values are valid
     new_key: List[Tuple[str, int]] = []
@@ -416,7 +416,8 @@ class MSv2Structure(Mapping):
       column = SHORT_TO_LONG_PARTITION_COLUMNS.get(column, column)
       if column not in column_set:
         raise InvalidPartitionKey(
-          f"{column} is not valid a valid partition column " f"{self._partition_schema}"
+          f"{column} is not valid a valid partition column "
+          f"{self._partition_columns}"
         )
       if not isinstance(value, Integral):
         raise InvalidPartitionKey(f"{value} is not a valid partition value")

--- a/xarray_ms/casa_types.py
+++ b/xarray_ms/casa_types.py
@@ -32,6 +32,7 @@ CASA_TO_NUMPY_MAP = {
   "FCOMPLEX": np.complex64,
   "COMPLEX": np.complex64,
   "DCOMPLEX": np.complex128,
+  "RECORD": object,
   "STRING": object,
 }
 

--- a/xarray_ms/testing/simulator.py
+++ b/xarray_ms/testing/simulator.py
@@ -103,6 +103,7 @@ class MSStructureSimulator:
 
   ntime: int
   nantenna: int
+  nfield: int
   auto_corrs: bool
   dump_rate: float
   time_chunks: int
@@ -175,6 +176,7 @@ class MSStructureSimulator:
 
     self.ntime = ntime
     self.nantenna = nantenna
+    self.nfield = nfield
     self.auto_corrs = auto_corrs
     self.dump_rate = dump_rate
     self.time_chunks = time_chunks
@@ -197,6 +199,7 @@ class MSStructureSimulator:
   def simulate_ms(self, output_ms: str) -> None:
     """Simulate data into the given measurement set name"""
     table_desc = ADDITIONAL_COLUMNS if self.simulate_data else {}
+
     # Generate descriptors, create simulated data from the descriptors
     # and write simulated data to the main Measurement Set
     with Table.ms_from_descriptor(output_ms, "MAIN", table_desc) as T:
@@ -278,6 +281,15 @@ class MSStructureSimulator:
       T.putcol("NAME", np.asarray([f"ANTENNA-{i}" for i in range(self.nantenna)]))
       T.putcol("MOUNT", np.asarray(["ALT-AZ" for _ in range(self.nantenna)]))
       T.putcol("STATION", np.asarray([f"STATION-{i}" for i in range(self.nantenna)]))
+
+    with Table.from_filename(f"{output_ms}::FIELD", **kw) as T:
+      T.addrows(self.nfield)
+      T.putcol("NAME", np.asarray([f"FIELD-{i}" for i in range(self.nfield)]))
+      T.putcol("SOURCE_ID", np.arange(self.nfield))
+
+    with Table.ms_from_descriptor(output_ms, "SOURCE") as T:
+      T.addrows(self.nfield)
+      T.putcol("NAME", np.asarray([f"SOURCE-{i}" for i in range(self.nfield)]))
 
   def generate_descriptors(self) -> Generator[PartitionDescriptor, None, None]:
     """Generates a sequence of descriptors, each corresponding to a partition"""


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

- Partitioning by columns of the `FIELD` and `STATE` tables is now supported.
- Datasets can now be partitioned by `SOURCE_ID` and `OBS_MODE`.
- Default partitioning is `["DATA_DESC_ID", "OBS_MODE", "OBSERVATION_ID"]`.

<!-- dummy -->

- [x] Test Cases covering your PR.
- [x] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--55.org.readthedocs.build/en/55/

<!-- readthedocs-preview xarray-ms end -->