### PR TITLE
Allow varying intervals in the last timestep of a partition

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Allow varying intervals in the last timestep of a partition (:pr:`61`)
 * Rename ANTENNA dataset to antenna_xds (:pr:`60`)
 * Depend on arcae ^0.2.7 (:pr:`59`)
 * Fix test cases that succeeded after attributes changed (:pr:`57`)

--- a/xarray_ms/backend/msv2/main_dataset_factory.py
+++ b/xarray_ms/backend/msv2/main_dataset_factory.py
@@ -138,7 +138,9 @@ class MainDatasetFactory:
         f"{missing} / {row_map.size} ({100. * missing / row_map.size:.1f}%) "
         f"rows missing from the full (time, baseline_id) grid "
         f"in partition {self._partition_key}. "
-        f"Dataset variables will be padded",
+        f"Dataset variables will be padded with nans "
+        f"in the case of data variables "
+        f"and flags will be set",
         IrregularGridWarning,
       )
 
@@ -184,7 +186,8 @@ class MainDatasetFactory:
         f"Multiple intervals {partition.interval} "
         f"found in partition {self._partition_key}. "
         f'Setting time.attrs["integration_time"] = nan and '
-        f"adding full resolution TIME and INTERVAL columns. ",
+        f"adding full resolution TIME and INTEGRATION_TIME columns. "
+        f"{'They contain nans in missing rows' if missing else ''}",
         IrregularGridWarning,
       )
       time_attrs = {"integration_time": np.nan}
@@ -223,7 +226,7 @@ class MainDatasetFactory:
         f"adding full resolution CHANNEL_FREQUENCY column. ",
       )
       raise NotImplementedError(
-        "Full resolution CHANNEL_FREQUENCY " " and CHANNEL_WIDTH columns"
+        "Full resolution CHANNEL_FREQUENCY and CHANNEL_WIDTH columns"
       )
 
     coordinates.append(


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

The intervals in the last timestep of an averaged Measurement Set are often smaller than the the other timesteps as there can be insufficient data to fill the final averaging bin. As INTERVAL (in MSv2) and EFFECTIVE_INTEGRATION_TIME (Msv4) are effective values, it is possible to simply use the unique interval from the other timesteps and ignore differing values in the final timestamp.


- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--61.org.readthedocs.build/en/61/

<!-- readthedocs-preview xarray-ms end -->