### PR TITLE
Extend the antenna dataset implementation

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Extend the antenna dataset implementation (:pr:`77`)
 * Fix MSv2Store._partition_key typing (:pr:`76`)
 * Add observation_info attribute (:pr:`74`)
 * Add ANTENNA_DISH_DIAMETER variable to antenna dataset (:pr:`73`)

--- a/tests/test_antenna.py
+++ b/tests/test_antenna.py
@@ -1,0 +1,110 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+import xarray
+from arcae.lib.arrow_tables import Table, ms_descriptor
+
+NANTENNA = 4
+
+
+@pytest.mark.parametrize(
+  "simmed_ms",
+  [
+    {
+      "name": "backend.ms",
+      "nantenna": NANTENNA,
+      "data_description": [(8, ["XX", "XY", "YX", "YY"]), (4, ["RR", "LL"])],
+    }
+  ],
+  indirect=True,
+)
+def test_antenna_feed_join(simmed_ms):
+  """Tests a number of cases for the join of the ANTENNA and FEED subtables."""
+
+  def _fill_other_columns(T, index):
+    """Fill other feed columns with boilerplate"""
+    T.putcol("NUM_RECEPTORS", np.array([2]), index=index)
+    T.putcol("BEAM_OFFSET", np.full((1, 2, 2), 0.1), index=index)
+    T.putcol("RECEPTOR_ANGLE", np.full((1, 2), 0.1), index=index)
+    T.putcol("POL_RESPONSE", np.full((1, 2, 2), 0.1 + 0.1j), index=index)
+
+  feed_table_desc = ms_descriptor("FEED", complete=True)
+  with Table.ms_from_descriptor(simmed_ms, "FEED", table_desc=feed_table_desc) as T:
+    # Test some antenna, feed, spw combinations
+    # Due to the internal simulator logic and the above
+    # data_description configuration, we get two partitions
+    # with partition 0 containing SPW 0 == FEED 1
+    # and partition 1 containing SPW 1 == FEED 0
+    T.addrows(7)
+
+    # Add ANTENNA-0 to second partition
+    index = (np.array([0]),)
+    T.putcol("SPECTRAL_WINDOW_ID", np.array([1]), index=index)
+    T.putcol("FEED_ID", np.array([0]), index=index)
+    T.putcol("ANTENNA_ID", np.array([0]), index=index)
+    T.putcol("POLARIZATION_TYPE", np.array([["R", "L"]]), index=index)
+    _fill_other_columns(T, index)
+
+    # Add ANTENNA-1 to first partition
+    index = (np.array([1]),)
+    T.putcol("SPECTRAL_WINDOW_ID", np.array([0]), index=index)
+    T.putcol("FEED_ID", np.array([1]), index=index)
+    T.putcol("ANTENNA_ID", np.array([1]), index=index)
+    T.putcol("POLARIZATION_TYPE", np.array([["X", "Y"]]), index=index)
+    _fill_other_columns(T, index)
+
+    # Add ANTENNA-2 to second partition (SPW_ID = -1 and FEED_ID = 0)
+    index = (np.array([2]),)
+    T.putcol("SPECTRAL_WINDOW_ID", np.array([-1]), index=index)
+    T.putcol("FEED_ID", np.array([0]), index=index)
+    T.putcol("ANTENNA_ID", np.array([2]), index=index)
+    T.putcol("POLARIZATION_TYPE", np.array([["R", "L"]]), index=index)
+    _fill_other_columns(T, index)
+
+    # Add ANTENNA-2 to first partition (SPW_ID = -1 and FEED_ID = 1)
+    index = (np.array([3]),)
+    T.putcol("SPECTRAL_WINDOW_ID", np.array([-1]), index=index)
+    T.putcol("FEED_ID", np.array([1]), index=index)
+    T.putcol("ANTENNA_ID", np.array([2]), index=index)
+    T.putcol("POLARIZATION_TYPE", np.array([["X", "Y"]]), index=index)
+    _fill_other_columns(T, index)
+
+    # Add ANTENNA-3 link to non-existent MAIN table FEED
+    index = (np.array([4]),)
+    T.putcol("SPECTRAL_WINDOW_ID", np.array([-1]), index=index)
+    T.putcol("FEED_ID", np.array([2]), index=index)
+    T.putcol("ANTENNA_ID", np.array([3]), index=index)
+    T.putcol("POLARIZATION_TYPE", np.array([["R", "L"]]), index=index)
+    _fill_other_columns(T, index)
+
+    # Add ANTENNA-4 link to non-existent partition (SPW_ID = 1, FEED_ID = 1)
+    index = (np.array([5]),)
+    T.putcol("SPECTRAL_WINDOW_ID", np.array([1]), index=index)
+    T.putcol("FEED_ID", np.array([1]), index=index)
+    T.putcol("ANTENNA_ID", np.array([3]), index=index)
+    T.putcol("POLARIZATION_TYPE", np.array([["R", "L"]]), index=index)
+    _fill_other_columns(T, index)
+
+    # Add ANTENNA-5 link to non-existent partition (SPW_ID = 0, FEED_ID = 0)
+    index = (np.array([6]),)
+    T.putcol("SPECTRAL_WINDOW_ID", np.array([0]), index=index)
+    T.putcol("FEED_ID", np.array([0]), index=index)
+    T.putcol("ANTENNA_ID", np.array([4]), index=index)
+    T.putcol("POLARIZATION_TYPE", np.array([["R", "L"]]), index=index)
+    _fill_other_columns(T, index)
+
+  dt = xarray.open_datatree(simmed_ms)
+  assert list(dt.children) == ["backend_partition_000", "backend_partition_001"]
+
+  p0 = dt["backend_partition_000"]
+  p1 = dt["backend_partition_001"]
+
+  npt.assert_array_equal(p0.polarization, ["XX", "XY", "YX", "YY"])
+  npt.assert_array_equal(p1.polarization, ["RR", "LL"])
+
+  npt.assert_array_equal(
+    p0["antenna_xds"].antenna_name, np.array(["ANTENNA-1", "ANTENNA-2"], dtype=object)
+  )
+  npt.assert_array_equal(
+    p1["antenna_xds"].antenna_name, np.array(["ANTENNA-0", "ANTENNA-2"], dtype=object)
+  )

--- a/xarray_ms/backend/msv2/antenna_dataset_factory.py
+++ b/xarray_ms/backend/msv2/antenna_dataset_factory.py
@@ -1,39 +1,120 @@
 from typing import Mapping
 
+import numpy as np
 from xarray import Dataset, Variable
 
-from xarray_ms.backend.msv2.structure import MSv2StructureFactory
+from xarray_ms.backend.msv2.structure import MSv2StructureFactory, PartitionKeyT
+from xarray_ms.errors import InvalidMeasurementSet
+
+RELOCATABLE_ARRAY = {"ALMA", "VLA", "NOEMA", "EVLA"}
 
 
 class AntennaDatasetFactory:
+  _partition_key: PartitionKeyT
   _structure_factory: MSv2StructureFactory
 
-  def __init__(self, structure_factory: MSv2StructureFactory):
+  def __init__(
+    self, partition_key: PartitionKeyT, structure_factory: MSv2StructureFactory
+  ):
+    self._partition_key = partition_key
     self._structure_factory = structure_factory
 
   def get_dataset(self) -> Mapping[str, Variable]:
-    ants = self._structure_factory()._ant
+    structure = self._structure_factory()
+    partition = structure[self._partition_key]
+    ants = structure._ant
+    feeds = structure._feed
 
     import pyarrow.compute as pac
 
-    position = pac.list_flatten(ants["POSITION"]).to_numpy().reshape(-1, 3)
-    diameter = ants["DISH_DIAMETER"].to_numpy()
+    feed_id = feeds["FEED_ID"].to_numpy()
+    spw_id = feeds["SPECTRAL_WINDOW_ID"].to_numpy()
+    feed_ant_id = feeds["ANTENNA_ID"].to_numpy()
+    # Select feeds with global spws (-1) or that match the partition spw
+    feed_mask = np.logical_or(spw_id == -1, spw_id == partition.spw_id)
+    # Select feed_id's matching the partition feeds
+    np.logical_and(feed_mask, feed_id == partition.feed_id, out=feed_mask)
+
+    # NOTE: This outer product could potentially be large
+    # and could be ameliorated by selecting out feed_ant_id[None, feed_mask]
+    ant_id = np.arange(len(ants))
+    ant_feed_map = ant_id[:, None] == feed_ant_id[None, :]
+    np.logical_and(ant_feed_map, feed_mask[None, :], out=ant_feed_map)
+    ant_mask = np.any(ant_feed_map, axis=1)
+
+    filtered_ants = ants.filter(ant_mask)
+
+    if len(filtered_ants) == 0:
+      raise InvalidMeasurementSet(
+        f"No antennas were found in FEED matching "
+        f"feed_id = {partition.feed_id} and spw_id = {partition.spw_id}"
+      )
+
+    antenna_names = filtered_ants["NAME"].to_numpy()
+    telescope_names = np.asarray([partition.telescope_name] * len(antenna_names))
+    position = pac.list_flatten(filtered_ants["POSITION"]).to_numpy().reshape(-1, 3)
+    diameter = filtered_ants["DISH_DIAMETER"].to_numpy()
+    station = filtered_ants["STATION"].to_numpy()
+    mount = filtered_ants["MOUNT"].to_numpy()
+
+    filtered_feeds = feeds.take(np.where(ant_feed_map)[-1])
+    nreceptors = filtered_feeds["NUM_RECEPTORS"].unique().to_numpy()
+
+    if len(nreceptors) != 1 or nreceptors.item() != 2:
+      raise NotImplementedError(
+        f"Representation of Measurement Sets with "
+        f"FEED::NUM_RECEPTORS != 2: {nreceptors.tolist()}"
+      )
+
+    receptor_angle = (
+      pac.list_flatten(filtered_feeds["RECEPTOR_ANGLE"]).to_numpy().reshape(-1, 2)
+    )
+    pol_type = (
+      pac.list_flatten(filtered_feeds["POLARIZATION_TYPE"]).to_numpy().reshape(-1, 2)
+    )
+    receptor_labels = [f"pol_{i}" for i in range(nreceptors.item())]
+
+    metre_attrs = {"units": ["m"], "type": "quantity"}
+    rad_attrs = {"units": ["rad"], "type": "quantity"}
+
+    data_vars = {
+      "ANTENNA_POSITION": Variable(
+        ("antenna_name", "cartesian_pos_label"),
+        position,
+        {
+          "coordinate_system": "geocentric",
+          "origin_object_name": "earth",
+        },
+      ),
+      "ANTENNA_DISH_DIAMETER": Variable("antenna_name", diameter, metre_attrs),
+      "ANTENNA_EFFECTIVE_DISH_DIAMETER": Variable(
+        "antenna_name", diameter, metre_attrs
+      ),
+      "ANTENNA_RECEPTOR_ANGLE": Variable(
+        ("antenna_name", "receptor_label"), receptor_angle, rad_attrs
+      ),
+    }
+
+    if "FOCUS_LENGTH" in filtered_feeds:
+      focus_length = filtered_feeds["FOCUS_LENGTH"].to_numpy()
+      data_vars["ANTENNA_FOCUS_LENGTH"] = Variable(
+        "antenna_name", focus_length, metre_attrs
+      )
 
     return Dataset(
-      data_vars={
-        "ANTENNA_POSITION": Variable(("antenna_name", "cartesian_pos_label"), position),
-        "ANTENNA_DISH_DIAMETER": Variable(("antenna_name",), diameter),
-      },
+      data_vars=data_vars,
       coords={
-        "antenna_name": Variable("antenna_name", ants["NAME"].to_numpy()),
-        "mount": Variable(
-          "antenna_name",
-          ants["MOUNT"].to_numpy(),
-        ),
-        "station": Variable(
-          "antenna_name",
-          ants["STATION"].to_numpy(),
-        ),
-        "cartesian_pos_label": Variable(("cartesian_pos_label",), ["x", "y", "z"]),
+        "antenna_name": Variable("antenna_name", antenna_names),
+        "mount": Variable("antenna_name", mount),
+        "telescope_name": Variable("telescope_name", telescope_names),
+        "station": Variable("antenna_name", station),
+        "cartesian_pos_label": Variable("cartesian_pos_label", ["x", "y", "z"]),
+        "polarization_type": Variable(("antenna_name", "receptor_label"), pol_type),
+        "receptor_label": Variable("receptor_label", receptor_labels),
+      },
+      attrs={
+        "type": "antenna",
+        "overall_telescope_name": partition.telescope_name,
+        "relocatable_antennas": partition.telescope_name in RELOCATABLE_ARRAY,
       },
     )

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -440,7 +440,7 @@ class MSv2EntryPoint(BackendEntrypoint):
         **kwargs,
       )
 
-      antenna_factory = AntennaDatasetFactory(structure_factory)
+      antenna_factory = AntennaDatasetFactory(partition_key, structure_factory)
 
       path = f"{ms_name}_partition_{p:03}"
       datasets[path] = ds

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -168,6 +168,7 @@ class PartitionData:
   time: npt.NDArray[np.float64]
   interval: npt.NDArray[np.float64]
   scan_numbers: List[int]
+  feed_id: int
   # Polarization
   corr_type: npt.NDArray[np.int32]
   # Field
@@ -175,6 +176,7 @@ class PartitionData:
   line_names: List[str]
   source_names: List[str]
   # Spectral Window
+  spw_id: int
   spw_name: str
   spw_freq_group_name: str
   spw_ref_freq: float
@@ -635,6 +637,16 @@ class MSv2Structure(Mapping):
         f"FEED2: {ufeed2.tolist()}."
       )
 
+    if feed1_id != feed2_id:
+      raise NotImplementedError(
+        f"FEED1 != FEED2 ({feed1_id} != {feed2_id}) "
+        f"in partition {key}. Differing FEED ids "
+        f"per DATA_DESC_ID are currently regarded "
+        f"as an edge case of interest. "
+        f"Consider raising a github issue "
+        f"regarding your Measurement Set."
+      )
+
     # Compute the unique times and their inverse index
     utime, time_ids = self.par_unique(pool, ncpus, time, return_inverse=True)
 
@@ -781,6 +793,8 @@ class MSv2Structure(Mapping):
       field_names=field_names,
       line_names=line_names,
       source_names=source_names,
+      feed_id=feed1_id,
+      spw_id=spw_id,
       spw_name=spw_name,
       spw_freq_group_name=spw_freq_group_name,
       spw_ref_freq=spw_ref_freq,


### PR DESCRIPTION
The existing antenna dataset implementation only filled out the ANTENNA_POSITION variable, as well as some coordinates.

This PR implements a full join on the MSv2 ANTENNA, FEED and MAIN table and fills out the remaining variables and coordinates.

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->


- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--77.org.readthedocs.build/en/77/

<!-- readthedocs-preview xarray-ms end -->