### PR TITLE
Refactor partitioning logic

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Refactor partitioning logic to be more robust (:pr:`78`)
+* The set of ANTENNA's related to a partition in the FEED table is
+  used to create the antenna dataset for that partition (:pr:`78`)
+* Metadata extraction moved to dataset factories (:pr:`78`)
 * Extend the antenna dataset implementation (:pr:`77`)
 * Fix MSv2Store._partition_key typing (:pr:`76`)
 * Add observation_info attribute (:pr:`74`)

--- a/xarray_ms/backend/msv2/antenna_dataset_factory.py
+++ b/xarray_ms/backend/msv2/antenna_dataset_factory.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from typing import Dict, Mapping
 
 import numpy as np
 from xarray import Dataset, Variable
@@ -13,28 +13,24 @@ RELOCATABLE_ARRAY = {"ALMA", "VLA", "NOEMA", "EVLA"}
 class AntennaDatasetFactory:
   _partition_key: PartitionKeyT
   _structure_factory: MSv2StructureFactory
-  _antenna_factory: TableFactory
+  _subtable_factories: Dict[str, TableFactory]
 
   def __init__(
     self,
     partition_key: PartitionKeyT,
     structure_factory: MSv2StructureFactory,
-    antenna_factory: TableFactory,
-    feed_factory: TableFactory,
-    observation_factory: TableFactory,
+    subtable_factories: Dict[str, TableFactory],
   ):
     self._partition_key = partition_key
     self._structure_factory = structure_factory
-    self._antenna_factory = antenna_factory
-    self._feed_factory = feed_factory
-    self._observation_factory = observation_factory
+    self._subtable_factories = subtable_factories
 
   def get_dataset(self) -> Mapping[str, Variable]:
     structure = self._structure_factory()
     partition = structure[self._partition_key]
-    ants = self._antenna_factory()
-    feeds = self._feed_factory()
-    obs = self._observation_factory()
+    ants = self._subtable_factories["ANTENNA"]()
+    feeds = self._subtable_factories["FEED"]()
+    obs = self._subtable_factories["OBSERVATION"]()
 
     telescope_name = obs["TELESCOPE_NAME"][partition.obs_id].as_py()
 

--- a/xarray_ms/backend/msv2/main_dataset_factory.py
+++ b/xarray_ms/backend/msv2/main_dataset_factory.py
@@ -16,6 +16,7 @@ from xarray_ms.backend.msv2.encoders import (
 )
 from xarray_ms.backend.msv2.structure import MSv2StructureFactory, PartitionKeyT
 from xarray_ms.backend.msv2.table_factory import TableFactory
+from xarray_ms.casa_types import ColumnDesc, FrequencyMeasures, Polarisations
 from xarray_ms.errors import IrregularGridWarning
 
 
@@ -48,26 +49,44 @@ FIXED_DIMENSION_SIZES = {"uvw_label": 3}
 class MainDatasetFactory:
   _partition_key: PartitionKeyT
   _preferred_chunks: Dict[str, int]
-  _table_factory: TableFactory
+  _ms_factory: TableFactory
   _structure_factory: MSv2StructureFactory
+  _antenna_factory: TableFactory
+  _spw_factory: TableFactory
+  _pol_factory: TableFactory
+  _obs_factory: TableFactory
+  _column_descs: Dict[str, ColumnDesc]
 
   def __init__(
     self,
     partition_key: PartitionKeyT,
     preferred_chunks: Dict[str, int],
-    table_factory: TableFactory,
+    ms_factory: TableFactory,
     structure_factory: MSv2StructureFactory,
+    antenna_factory: TableFactory,
+    spw_factory: TableFactory,
+    pol_factory: TableFactory,
+    obs_factory: TableFactory,
   ):
     self._partition_key = partition_key
     self._preferred_chunks = preferred_chunks
-    self._table_factory = table_factory
+    self._ms_factory = ms_factory
     self._structure_factory = structure_factory
+    self._antenna_factory = antenna_factory
+    self._spw_factory = spw_factory
+    self._pol_factory = pol_factory
+    self._obs_factory = obs_factory
+
+    ms = ms_factory()
+    ms_table_desc = ms.tabledesc()
+    self._main_column_descs = {
+      c: ColumnDesc.from_descriptor(c, ms_table_desc) for c in ms.columns()
+    }
 
   def _variable_from_column(self, column: str) -> Variable:
     """Derive an xarray Variable from the MSv2 column descriptor and schemas"""
     structure = self._structure_factory()
     partition = structure[self._partition_key]
-    main_column_descs = structure.column_descs["MAIN"]
 
     try:
       schema = MSV4_to_MSV2_COLUMN_SCHEMAS[column]
@@ -75,15 +94,18 @@ class MainDatasetFactory:
       raise KeyError(f"Column {column} was not present")
 
     try:
-      column_desc = main_column_descs[schema.name]
+      column_desc = self._main_column_descs[schema.name]
     except KeyError:
       raise KeyError(f"No Column Descriptor exist for {schema.name}")
 
+    chan_freq = self._spw_factory()["CHAN_FREQ"][partition.spw_id].as_py()
+    corr_type = self._pol_factory()["CORR_TYPE"][partition.pol_id].as_py()
+
     dim_sizes = {
       "time": len(partition.time),
-      "baseline_id": structure.nbl,
-      "frequency": len(partition.chan_freq),
-      "polarization": len(partition.corr_type),
+      "baseline_id": partition.nbl,
+      "frequency": len(chan_freq),
+      "polarization": len(corr_type),
       **FIXED_DIMENSION_SIZES,
     }
 
@@ -97,7 +119,7 @@ class MainDatasetFactory:
     default = column_desc.dtype.type(schema.default)
 
     data = MSv2Array(
-      self._table_factory,
+      self._ms_factory,
       self._structure_factory,
       self._partition_key,
       schema.name,
@@ -110,7 +132,7 @@ class MainDatasetFactory:
 
     # Apply any measures encoding
     if schema.coder:
-      coder = schema.coder(schema.name, structure.column_descs["MAIN"])
+      coder = schema.coder(schema.name, self._main_column_descs)
       var = coder.decode(var)
 
     dims, data, attrs, encoding = unpack_for_decoding(var)
@@ -123,13 +145,28 @@ class MainDatasetFactory:
   def get_variables(self) -> Mapping[str, Variable]:
     structure = self._structure_factory()
     partition = structure[self._partition_key]
-    ant1, ant2 = structure.antenna_pairs
-    nbl = structure.nbl
+    ant1, ant2 = partition.antenna_pairs
+    nbl = partition.nbl
     assert (nbl,) == ant1.shape
 
-    ant_names = structure._ant["NAME"].to_numpy()
+    ant_names = self._antenna_factory()["NAME"].to_numpy()
     ant1_names = ant_names[ant1]
     ant2_names = ant_names[ant2]
+
+    spw_id = partition.spw_id
+    pol_id = partition.pol_id
+    spw = self._spw_factory()
+    pol = self._pol_factory()
+
+    chan_freq = spw["CHAN_FREQ"][spw_id].as_py()
+    uchan_width = np.unique(spw["CHAN_WIDTH"][spw_id].as_py())
+    spw_name = spw["NAME"][spw_id].as_py()
+    spw_freq_group_name = spw["FREQ_GROUP_NAME"][spw_id].as_py()
+    spw_ref_freq = spw["REF_FREQUENCY"][spw_id].as_py()
+    spw_meas_freq_ref = spw["MEAS_FREQ_REF"][spw_id].as_py()
+    spw_frame = FrequencyMeasures(spw_meas_freq_ref).name.lower()
+
+    corr_type = Polarisations.from_values(pol["CORR_TYPE"][pol_id].as_py()).to_str()
 
     row_map = partition.row_map
     missing = np.count_nonzero(row_map == -1)
@@ -170,7 +207,7 @@ class MainDatasetFactory:
         "baseline_antenna2_name",
         (("baseline_id",), ant2_names, {"coordinates": "baseline_antenna2_name"}),
       ),
-      ("polarization", (("polarization",), partition.corr_type, None)),
+      ("polarization", (("polarization",), corr_type, None)),
       ("uvw_label", (("uvw_label",), ["u", "v", "w"], None)),
     ]
 
@@ -178,7 +215,7 @@ class MainDatasetFactory:
     coordinates = [(n, Variable(d, v, a, e)) for n, (d, v, a) in coordinates]
 
     # Add time coordinate
-    time_coder = TimeCoder("TIME", structure.column_descs["MAIN"])
+    time_coder = TimeCoder("TIME", self._main_column_descs)
 
     if partition.interval.size == 1:
       time_attrs = {"integration_time": partition.interval.item()}
@@ -206,22 +243,22 @@ class MainDatasetFactory:
     # Add frequency coordinate
     freq_attrs = {
       "type": "spectral_coord",
-      "frame": partition.spw_frame,
+      "frame": spw_frame,
       "units": ["Hz"],
-      "spectral_window_name": partition.spw_name or "<Unknown>",
-      "reference_frequency": partition.spw_ref_freq,
+      "spectral_window_name": spw_name or "<Unknown>",
+      "reference_frequency": spw_ref_freq,
       "effective_channel_width": "EFFECTIVE_CHANNEL_WIDTH",
     }
 
-    if partition.spw_freq_group_name:
-      freq_attrs["frequency_group_name"] = partition.spw_freq_group_name
+    if spw_freq_group_name:
+      freq_attrs["frequency_group_name"] = spw_freq_group_name
 
-    if partition.chan_width.size == 1:
-      freq_attrs["channel_width"] = partition.chan_width.item()
+    if uchan_width.size == 1:
+      freq_attrs["channel_width"] = uchan_width.item()
     else:
       freq_attrs["channel_width"] = np.nan
       warnings.warn(
-        f"Multiple channel widths {partition.chan_width} "
+        f"Multiple channel widths {uchan_width} "
         f"found in partition {self._partition_key}. "
         f'Setting frequency.attrs["channel_width"] = nan and '
         f"adding full resolution CHANNEL_FREQUENCY column.",
@@ -231,41 +268,22 @@ class MainDatasetFactory:
         "Full resolution CHANNEL_FREQUENCY and CHANNEL_WIDTH columns"
       )
 
-    coordinates.append(
-      ("frequency", Variable("frequency", partition.chan_freq, freq_attrs))
-    )
+    coordinates.append(("frequency", Variable("frequency", chan_freq, freq_attrs)))
 
     return FrozenDict(sorted(data_vars + coordinates))
-
-  def _partition_info(self) -> Dict[Any, Any]:
-    structure = self._structure_factory()
-    partition = structure[self._partition_key]
-
-    return dict(
-      sorted(
-        {
-          "spectal_window_name": partition.spw_name,
-          "field_name": list(set(partition.field_names)),
-          "polarization_setup": partition.corr_type,
-          "scan_number": list(set(partition.scan_numbers)),
-          "sub_scan_number": list(set(partition.sub_scan_numbers)),
-          "source_name": list(set(partition.source_names)),
-          "line_name": list(map(list, set(map(tuple, partition.line_names)))),
-          "intent": list(set(partition.intents)),
-        }.items()
-      )
-    )
 
   def _observation_info(self) -> Dict[str, Any]:
     structure = self._structure_factory()
     partition = structure[self._partition_key]
+    obs = self._obs_factory()
+    observer = obs["OBSERVER"][partition.obs_id].as_py()
+    project = obs["PROJECT"][partition.obs_id].as_py()
 
     return dict(
       sorted(
         {
-          "observer": partition.observer,
-          "project": partition.project,
-          # "release_date": partition.release_date,
+          "observer": observer,
+          "project": project,
         }.items()
       )
     )
@@ -273,5 +291,4 @@ class MainDatasetFactory:
   def get_attrs(self) -> Dict[Any, Any]:
     return {
       "observation_info": self._observation_info(),
-      "partition_info": self._partition_info(),
     }

--- a/xarray_ms/backend/msv2/main_dataset_factory.py
+++ b/xarray_ms/backend/msv2/main_dataset_factory.py
@@ -278,6 +278,8 @@ class MainDatasetFactory:
     obs = self._obs_factory()
     observer = obs["OBSERVER"][partition.obs_id].as_py()
     project = obs["PROJECT"][partition.obs_id].as_py()
+    # TODO: A Measures conversions is needed here
+    release_date = obs["RELEASE_DATE"][partition.obs_id].as_py()  # noqa: F841
 
     return dict(
       sorted(

--- a/xarray_ms/backend/msv2/partition.py
+++ b/xarray_ms/backend/msv2/partition.py
@@ -1,0 +1,97 @@
+import concurrent.futures as cf
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+import numpy.typing as npt
+import pyarrow as pa
+from arcae.lib.arrow_tables import merge_np_partitions
+
+PartitionKeyT = Tuple[Tuple[str, int | str], ...]
+
+
+class TablePartitioner:
+  """Partitions and sorts MSv2 indexing columns"""
+
+  _partitionby: List[str]
+  _sortby: List[str]
+  _other: List[str]
+
+  def __init__(
+    self, partitionby: Sequence[str], sortby: Sequence[str], other: Sequence[str]
+  ):
+    self._partitionby = list(partitionby)
+    self._sortby = list(sortby)
+    self._other = list(other)
+
+  def partition(
+    self, index: pa.Table, pool: cf.ThreadPoolExecutor
+  ) -> Dict[PartitionKeyT, Dict[str, npt.NDArray]]:
+    other = set(self._other)
+
+    try:
+      other.remove("row")
+      index = index.append_column(
+        "row", pa.array(np.arange(len(index), dtype=np.int64))
+      )
+    except KeyError:
+      pass
+
+    nrow = len(index)
+    nworkers = pool._max_workers
+    chunk = (nrow + nworkers - 1) // nworkers
+
+    # Order columns by
+    #
+    # 1. Partitioning columns
+    # 2. Sorting columns
+    # 3. Others (such as row and INTERVAL)
+    # 4. Remaining columns
+    #
+    # 4 is needed for the merge_np_partitions to work
+    ordered_columns = self._partitionby + self._sortby + self._other
+    ordered_columns += list(set(index.column_names) - set(ordered_columns))
+
+    # Create a dictionary out of the pyarrow table
+    table_dict = {k: index[k].to_numpy() for k in ordered_columns}
+    # Partition the data over the workers in the pool
+    partitions = [
+      {k: v[s : s + chunk] for k, v in table_dict.items()}
+      for s in range(0, nrow, chunk)
+    ]
+
+    # Sort each partition in parallel
+    def sort_partition(p):
+      sort_arrays = tuple(p[k] for k in reversed(ordered_columns))
+      indices = np.lexsort(sort_arrays)
+      return {k: v[indices] for k, v in p.items()}
+
+    partitions = list(pool.map(sort_partition, partitions))
+    # Merge partitions
+    merged = merge_np_partitions(partitions)
+
+    # Find the edges of the group partitions in parallel by
+    # partitioning the sorted merged values into chunks, including
+    # the starting value of the next chunk.
+    starts = list(range(0, nrow, chunk))
+    group_values = [
+      {k: v[s : s + chunk + 1] for k, v in merged.items() if k in self._partitionby}
+      for s in starts
+    ]
+    assert len(starts) == len(group_values)
+
+    # Find the group start and end points in parallel by finding edges
+    def find_edges(p, s):
+      diffs = [np.diff(p[v]) > 0 for v in self._partitionby]
+      return np.where(np.logical_or.reduce(diffs))[0] + s + 1
+
+    edges = list(pool.map(find_edges, group_values, starts))
+    group_offsets = np.concatenate([[0]] + edges + [[nrow]])
+
+    # Create the grouped partitions
+    groups: Dict[PartitionKeyT, Dict[str, npt.NDArray]] = {}
+
+    for start, end in zip(group_offsets[:-1], group_offsets[1:]):
+      key = tuple(sorted((k, merged[k][start].item()) for k in self._partitionby))
+      groups[key] = {k: v[start:end] for k, v in merged.items()}
+
+    return groups

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -615,10 +615,11 @@ class MSv2Structure(Mapping):
   ) -> None:
     """Populate the row map and interval grids"""
     # Normalise the antenna id's to np.arange(feed_antennas)
-    a1 = np.searchsorted(feed_antennas, antenna1)
-    a2 = np.searchsorted(feed_antennas, antenna2)
+    if not np.all(feed_antennas == np.arange(feed_antennas.size)):
+      antenna1 = np.searchsorted(feed_antennas, antenna1)
+      antenna2 = np.searchsorted(feed_antennas, antenna2)
     index = time_ids * nbl
-    index += baseline_id(a1, a2, na, auto_corrs)
+    index += baseline_id(antenna1, antenna2, na, auto_corrs)
     row_map[index] = rows
     interval_grid[index] = intervals
 

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -543,10 +543,6 @@ class MSv2Structure(Mapping):
     with Table.from_filename(subtable_path, lockoptions="nolock") as T:
       return T.to_arrow(columns=list(columns))
 
-  @property
-  def ms_factory(self) -> TableFactory:
-    return self._ms_factory
-
   def __init__(
     self, ms: TableFactory, partition_schema: List[str], auto_corrs: bool = True
   ):

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -614,8 +614,9 @@ class MSv2Structure(Mapping):
     auto_corrs: bool,
   ) -> None:
     """Populate the row map and interval grids"""
-    # Normalise the antenna id's to np.arange(feed_antennas)
-    if not np.all(feed_antennas == np.arange(feed_antennas.size)):
+    normed_antennas = np.arange(feed_antennas.size, dtype=feed_antennas.dtype)
+    # Perhaps normalise the antenna id's to np.arange(feed_antennas)
+    if not np.all(feed_antennas == normed_antennas):
       antenna1 = np.searchsorted(feed_antennas, antenna1)
       antenna2 = np.searchsorted(feed_antennas, antenna2)
     index = time_ids * nbl

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -370,8 +370,10 @@ class MSv2Structure(Mapping):
     def par_assign(sid, fid):
       sid[:] = field_source_id[fid]
 
-    pool.map(
-      par_assign, partition_args(source_id, chunk), partition_args(field_id, chunk)
+    list(
+      pool.map(
+        par_assign, partition_args(source_id, chunk), partition_args(field_id, chunk)
+      )
     )
     return source_id
 
@@ -391,8 +393,10 @@ class MSv2Structure(Mapping):
     def par_assign(ssn, sid):
       ssn[:] = state_ssn[sid]
 
-    pool.map(
-      par_assign, partition_args(subscan_nr, chunk), partition_args(state_id, chunk)
+    list(
+      pool.map(
+        par_assign, partition_args(subscan_nr, chunk), partition_args(state_id, chunk)
+      )
     )
     return subscan_nr
 
@@ -426,8 +430,10 @@ class MSv2Structure(Mapping):
     def par_assign(oid, sid):
       oid[:] = state_id_obs_mode_id_map[sid]
 
-    pool.map(
-      par_assign, partition_args(obs_mode_id, chunk), partition_args(state_id, chunk)
+    list(
+      pool.map(
+        par_assign, partition_args(obs_mode_id, chunk), partition_args(state_id, chunk)
+      )
     )
     return obs_mode_id, dict(obs_mode_state_id_map)
 
@@ -478,7 +484,7 @@ class MSv2Structure(Mapping):
       def par_assign(target, data):
         target[:] = data
 
-      data_ids = pool.map(inv_fn, udatas, indices)
+      data_ids = list(pool.map(inv_fn, udatas, indices))
       inverse = np.empty(len(data), dtype=indices[0].dtype)
       list(pool.map(par_assign, partition_args(inverse, chunk_size), data_ids))
 

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -24,9 +24,10 @@ from typing import (
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
-from arcae.lib.arrow_tables import Table, merge_np_partitions
+from arcae.lib.arrow_tables import Table
 from cacheout import Cache
 
+from xarray_ms.backend.msv2.partition import PartitionKeyT, TablePartitioner
 from xarray_ms.backend.msv2.table_factory import TableFactory
 from xarray_ms.errors import (
   InvalidMeasurementSet,
@@ -222,97 +223,6 @@ class PartitionData:
     a1, a2 = np.triu_indices(self.na, 0 if self.auto_corrs else 1)
     aids = np.asarray(self.antenna_ids, np.int32)
     return aids[a1], aids[a2]
-
-
-PartitionKeyT = Tuple[Tuple[str, int | str], ...]
-
-
-class TablePartitioner:
-  """Partitions and sorts MSv2 indexing columns"""
-
-  _partitionby: List[str]
-  _sortby: List[str]
-  _other: List[str]
-
-  def __init__(
-    self, partitionby: Sequence[str], sortby: Sequence[str], other: Sequence[str]
-  ):
-    self._partitionby = list(partitionby)
-    self._sortby = list(sortby)
-    self._other = list(other)
-
-  def partition(
-    self, index: pa.Table, pool: cf.ThreadPoolExecutor
-  ) -> Dict[PartitionKeyT, Dict[str, npt.NDArray]]:
-    other = set(self._other)
-
-    try:
-      other.remove("row")
-      index = index.append_column(
-        "row", pa.array(np.arange(len(index), dtype=np.int64))
-      )
-    except KeyError:
-      pass
-
-    nrow = len(index)
-    nworkers = pool._max_workers
-    chunk = (nrow + nworkers - 1) // nworkers
-
-    # Order columns by
-    #
-    # 1. Partitioning columns
-    # 2. Sorting columns
-    # 3. Others (such as row and INTERVAL)
-    # 4. Remaining columns
-    #
-    # 4 is needed for the merge_np_partitions to work
-    ordered_columns = self._partitionby + self._sortby + self._other
-    ordered_columns += list(set(index.column_names) - set(ordered_columns))
-
-    # Create a dictionary out of the pyarrow table
-    table_dict = {k: index[k].to_numpy() for k in ordered_columns}
-    # Partition the data over the workers in the pool
-    partitions = [
-      {k: v[s : s + chunk] for k, v in table_dict.items()}
-      for s in range(0, nrow, chunk)
-    ]
-
-    # Sort each partition in parallel
-    def sort_partition(p):
-      sort_arrays = tuple(p[k] for k in reversed(ordered_columns))
-      indices = np.lexsort(sort_arrays)
-      return {k: v[indices] for k, v in p.items()}
-
-    partitions = list(pool.map(sort_partition, partitions))
-    # Merge partitions
-    merged = merge_np_partitions(partitions)
-
-    # Find the edges of the group partitions in parallel by
-    # partitioning the sorted merged values into chunks, including
-    # the starting value of the next chunk.
-    starts = list(range(0, nrow, chunk))
-    group_values = [
-      {k: v[s : s + chunk + 1] for k, v in merged.items() if k in self._partitionby}
-      for s in starts
-    ]
-    assert len(starts) == len(group_values)
-
-    # Find the group start and end points in parallel by finding edges
-    def find_edges(p, s):
-      diffs = [np.diff(p[v]) > 0 for v in self._partitionby]
-      return np.where(np.logical_or.reduce(diffs))[0] + s + 1
-
-    edges = list(pool.map(find_edges, group_values, starts))
-    group_offsets = np.concatenate([[0]] + edges + [[nrow]])
-
-    # Create the grouped partitions
-    groups: Dict[PartitionKeyT, Dict[str, npt.NDArray]] = {}
-
-    for start, end in zip(group_offsets[:-1], group_offsets[1:]):
-      key = tuple(sorted((k, merged[k][start].item()) for k in self._partitionby))
-      groups[key] = {k: v[start:end] for k, v in merged.items()}
-
-    return groups
 
 
 def on_get_keep_alive(key, value, exists):

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -6,7 +6,6 @@ import logging
 import multiprocessing as mp
 import os.path
 from collections import defaultdict
-from datetime import datetime, timezone
 from functools import partial
 from numbers import Integral
 from typing import (
@@ -15,6 +14,7 @@ from typing import (
   Dict,
   Iterator,
   List,
+  Literal,
   Mapping,
   Sequence,
   Set,
@@ -26,14 +26,11 @@ import numpy.typing as npt
 import pyarrow as pa
 from arcae.lib.arrow_tables import Table, merge_np_partitions
 from cacheout import Cache
-from xarray.core.utils import FrozenDict
 
 from xarray_ms.backend.msv2.table_factory import TableFactory
-from xarray_ms.casa_types import ColumnDesc, FrequencyMeasures, Polarisations
 from xarray_ms.errors import (
   InvalidMeasurementSet,
   InvalidPartitionKey,
-  PartitioningError,
 )
 
 logger = logging.getLogger(__name__)
@@ -114,11 +111,13 @@ def partition_args(data: npt.NDArray, chunk: int) -> List[npt.NDArray]:
   return [data[i : i + chunk] for i in range(0, len(data), chunk)]
 
 
-DEFAULT_PARTITION_COLUMNS: List[str] = [
-  "DATA_DESC_ID",
-  "OBS_MODE",
-  "OBSERVATION_ID",
-]  #: Default Partitioning Column Schema
+DEFAULT_MAIN_PARTITION_COLUMNS: List[str] = ["DATA_DESC_ID", "OBSERVATION_ID"]
+
+DEFAULT_SUBTABLE_PARTITION_COLUMNS: List[str] = ["OBS_MODE"]
+
+DEFAULT_PARTITION_COLUMNS: List[str] = (
+  DEFAULT_MAIN_PARTITION_COLUMNS + DEFAULT_SUBTABLE_PARTITION_COLUMNS
+)  #: Default Partitioning Column Schema
 
 
 SHORT_TO_LONG_PARTITION_COLUMNS: Dict[str, str] = {
@@ -162,37 +161,67 @@ SORT_COLUMNS: List[str] = ["TIME", "ANTENNA1", "ANTENNA2"]
 
 @dataclasses.dataclass
 class PartitionData:
-  """Dataclass describing data unique to a partition"""
+  """Dataclass describing data unique to a partition
+
+  As `DATA_DESC_ID`, `OBSERVATION_ID` and `STATE::OBS_MODE` are
+  always part of the partitioning schema, values related to them
+  are singleton values.
+
+  For other cases, multiple values are generally assumed.
+  """
 
   # Main table
-  time: npt.NDArray[np.float64]
-  interval: npt.NDArray[np.float64]
+  time: npt.NDArray[np.float64]  # Unique timesteps
+  interval: npt.NDArray[np.float64]  # Unique intervals
+  obs_id: int  # unique from OBSERVATION_ID
+  spw_id: int  # unique from DATA_DESC_ID
+  pol_id: int  # unique from DATA_DESC_ID
+  # Multiple values per partition
+  antenna_ids: List[int]
+  feed_ids: List[int]
+  field_ids: List[int]
+  state_ids: List[int]
   scan_numbers: List[int]
-  feed_id: int
-  # Polarization
-  corr_type: npt.NDArray[np.int32]
-  # Field
-  field_names: List[str]
-  line_names: List[str]
-  source_names: List[str]
-  # Spectral Window
-  spw_id: int
-  spw_name: str
-  spw_freq_group_name: str
-  spw_ref_freq: float
-  spw_frame: str
-  chan_freq: npt.NDArray[np.float64]
-  chan_width: npt.NDArray[np.float64]
-  # State
-  intents: List[str]
+  # FIELD subtable
+  source_ids: List[int]
+  # STATE subtable
+  obs_mode: str  # unique from STATE::OBS_MODE
   sub_scan_numbers: List[int]
-  # Observation
-  telescope_name: str
-  observer: str
-  project: str
-  release_date: str
 
+  # Row to baseline map
   row_map: npt.NDArray[np.int64]
+
+  @property
+  def ntime(self) -> int:
+    """Number of timesteps"""
+    return self.row_map.shape[0]
+
+  @property
+  def nbl(self) -> int:
+    """Number of baselines"""
+    return self.row_map.shape[1]
+
+  @property
+  def na(self) -> int:
+    """Number of antenna"""
+    return len(self.antenna_ids)
+
+  @property
+  def auto_corrs(self) -> bool:
+    """Returns true if auto-correlations are included"""
+    if self.na * (self.na + 1) // 2 == self.nbl:
+      return True
+    elif self.na * (self.na - 1) // 2 == self.nbl:
+      return False
+    else:
+      raise RuntimeError(f"Invalid antenna {self.na} baseline {self.nbl} relation")
+
+  @property
+  def antenna_pairs(self) -> Tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]:
+    """Return per-baseline antenna pairs"""
+    a1, a2 = np.triu_indices(self.na, 0 if self.auto_corrs else 1)
+    aids = np.asarray(self.antenna_ids, np.int32)
+    return aids[a1], aids[a2]
 
 
 PartitionKeyT = Tuple[Tuple[str, int | str], ...]
@@ -352,18 +381,9 @@ class MSv2Structure(Mapping):
   """Holds structural information about an MSv2 dataset"""
 
   _ms_factory: TableFactory
-  _auto_corrs: bool
   _partition_columns: List[str]
+  _subtable_partition_columns: List[str]
   _partitions: Mapping[PartitionKeyT, PartitionData]
-  _column_descs: Dict[str, Dict[str, ColumnDesc]]
-  _ant: pa.Table
-  _ddid: pa.Table
-  _feed: pa.Table
-  _spw: pa.Table
-  _obs: pa.Table
-  _pol: pa.Table
-  _field: pa.Table
-  _state: pa.Table
 
   def __getitem__(self, key: PartitionKeyT) -> PartitionData:
     return self._partitions[key]
@@ -373,34 +393,6 @@ class MSv2Structure(Mapping):
 
   def __len__(self) -> int:
     return len(self._partitions)
-
-  @property
-  def auto_corrs(self) -> bool:
-    """Are auto-correlations included"""
-    return self._auto_corrs
-
-  @property
-  def column_descs(self) -> Dict[str, Dict[str, ColumnDesc]]:
-    """Return the per-table column descriptors.
-    Outer key is "MAIN", "SPECTRAL_WINDOW", inner key
-    is the column name such as "FLAG" and "WEIGHT_SPECTRUM"
-    """
-    return self._column_descs
-
-  @property
-  def na(self) -> int:
-    """Number of antenna in the Measurement Set"""
-    return len(self._ant)
-
-  @property
-  def antenna_pairs(self) -> Tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]:
-    """Return default per-baseline antenna pairs"""
-    return tuple(map(np.int32, np.triu_indices(self.na, 0 if self.auto_corrs else 1)))
-
-  @property
-  def nbl(self) -> int:
-    """Number of baselines in the Measurement Set"""
-    return nr_of_baselines(self.na, self.auto_corrs)
 
   @staticmethod
   def parse_partition_key(key: str) -> PartitionKeyT:
@@ -461,26 +453,82 @@ class MSv2Structure(Mapping):
 
     return matches
 
-  def maybe_get_source_id(
-    self, pool: cf.Executor, ncpus: int, field_id: npt.NDArray[np.int32]
-  ) -> npt.NDArray[np.int32] | None:
+  @staticmethod
+  def broadcast_source_id(
+    pool: cf.Executor,
+    ncpus: int,
+    field: pa.Table,
+    field_id: npt.NDArray[np.int32],
+  ) -> npt.NDArray[np.int32]:
     """Constructs a SOURCE_ID array from MAIN.FIELD_ID
     broadcast against FIELD.SOURCE_ID"""
-    if hasattr(self, "_field") and hasattr(self, "_source") and len(self._source) != 0:
-      field_source_id = self._field["SOURCE_ID"].to_numpy()
-      source_id = np.empty_like(field_id)
-      chunk = (len(source_id) + ncpus - 1) // ncpus
+    field_source_id = field["SOURCE_ID"].to_numpy()
+    source_id = np.empty_like(field_id)
+    chunk = (len(source_id) + ncpus - 1) // ncpus
 
-      def par_copy(source, field):
-        source[:] = field_source_id[field]
+    def par_assign(sid, fid):
+      sid[:] = field_source_id[fid]
 
-      pool.map(
-        par_copy, partition_args(source_id, chunk), partition_args(field_id, chunk)
-      )
+    pool.map(
+      par_assign, partition_args(source_id, chunk), partition_args(field_id, chunk)
+    )
+    return source_id
 
-      return source_id
+  @staticmethod
+  def broadcast_sub_scan_number(
+    pool: cf.Executor,
+    ncpus: int,
+    state: pa.Table,
+    state_id: npt.NDArray[npt.int32],
+  ) -> npt.NDArray[np.int32]:
+    """Constructs a SUB_SCAN_NUMBER array from MAIN.STATE_ID
+    broadcast against STATE.SUB_SCAN_NUMBER"""
+    state_ssn = state["SUB_SCAN"].to_numpy()
+    subscan_nr = np.empty_like(state_id)
+    chunk = (len(state_id) + ncpus - 1) // ncpus
 
-    return None
+    def par_assign(ssn, sid):
+      ssn[:] = state_ssn[sid]
+
+    pool.map(
+      par_assign, partition_args(subscan_nr, chunk), partition_args(state_id, chunk)
+    )
+    return subscan_nr
+
+  @staticmethod
+  def broadcast_obsmode_id(
+    pool: cf.Executor,
+    ncpus: int,
+    state: pa.Table,
+    state_id: npt.NDArray[npt.int32],
+  ) -> Tuple[npt.NDArray[np.int32], Dict[str, List[int]]]:
+    """Constructs an OBS_MODE_ID array from MAIN.STATE_ID broadcast
+    against unique entries in STATE.OBS_MODE"""
+    obs_mode = state["OBS_MODE"].to_numpy()
+
+    # Map unique observation modes to state_ids
+    obs_mode_state_id_map: Mapping[str, List[int]] = defaultdict(list)
+    for sid, obs_mode in enumerate(obs_mode):
+      obs_mode_state_id_map[obs_mode].append(sid)
+
+    # Generate the reverse mapping of state id's to unique observation mode id's
+    state_id_obs_mode_id_map = np.empty(len(state), np.int32)
+
+    for o, (obs_mode, state_ids) in enumerate(obs_mode_state_id_map.items()):
+      for sid in state_ids:
+        state_id_obs_mode_id_map[sid] = o
+
+    # Broadcast generated observation mode id's against MAIN.STATE_ID
+    obs_mode_id = np.empty_like(state_id)
+    chunk = (len(state_id) + ncpus - 1) // ncpus
+
+    def par_assign(oid, sid):
+      oid[:] = state_id_obs_mode_id_map[sid]
+
+    pool.map(
+      par_assign, partition_args(obs_mode_id, chunk), partition_args(state_id, chunk)
+    )
+    return obs_mode_id, dict(obs_mode_state_id_map)
 
   def partition_columns_from_schema(
     self, partition_schema: List[str]
@@ -493,39 +541,25 @@ class MSv2Structure(Mapping):
     """
     schema: Set[str] = set(partition_schema)
 
-    # Always partition by these columns
-    columns: Dict[str, None] = {c: None for c in DEFAULT_PARTITION_COLUMNS}
+    # Always partition by default columns
+    columns: Dict[str, None] = {c: None for c in DEFAULT_MAIN_PARTITION_COLUMNS}
+    subtable_columns: Dict[str, None] = {
+      c: None for c in DEFAULT_SUBTABLE_PARTITION_COLUMNS
+    }
 
     for column in VALID_MAIN_PARTITION_COLUMNS:
       if column in schema and column not in columns:
         columns[column] = None
 
-    # Add FIELD_ID if partitioning by FIELD columns
-    if (
-      len(set(VALID_FIELD_PARTITION_COLUMNS).intersection(schema)) > 0
-      and "FIELD_ID" not in columns
-    ):
-      columns["FIELD_ID"] = None
+    for column in VALID_FIELD_PARTITION_COLUMNS:
+      if column in schema and column not in subtable_columns:
+        subtable_columns[column] = None
 
-    # Add STATE_ID if partitioning by STATE columns
-    # and the STATE table is present and populated
-    if (
-      hasattr(self, "_state")
-      and len(self._state) != 0
-      and len(set(VALID_STATE_PARTITION_COLUMNS).intersection(schema)) > 0
-      and "STATE_ID" not in columns
-    ):
-      columns["STATE_ID"] = None
+    for column in VALID_STATE_PARTITION_COLUMNS:
+      if column in schema and column not in subtable_columns:
+        subtable_columns[column] = None
 
-    subtable_columns: List[str] = []
-    MAIN_COLUMN_SET: Set[str] = set(VALID_MAIN_PARTITION_COLUMNS)
-
-    for column in list(columns.keys()):
-      if column not in MAIN_COLUMN_SET:
-        subtable_columns.append(column)
-        del columns[column]
-
-    return list(columns.keys()), subtable_columns
+    return list(columns.keys()), list(subtable_columns.keys())
 
   @staticmethod
   def par_unique(pool, ncpus, data, return_inverse=False):
@@ -545,7 +579,7 @@ class MSv2Structure(Mapping):
 
       data_ids = pool.map(inv_fn, udatas, indices)
       inverse = np.empty(len(data), dtype=indices[0].dtype)
-      pool.map(par_assign, partition_args(inverse, chunk_size), data_ids)
+      list(pool.map(par_assign, partition_args(inverse, chunk_size), data_ids))
 
       return udata, inverse
     else:
@@ -553,262 +587,62 @@ class MSv2Structure(Mapping):
       return np.unique(np.concatenate(udata))
 
   @staticmethod
-  def read_subtables(
-    table_name: str,
-  ) -> Tuple[Dict[str, pa.Table], Dict[str, Dict[str, ColumnDesc]]]:
-    subtables: Dict[str, pa.Table] = {}
-    coldescs: Dict[str, Dict[str, ColumnDesc]] = defaultdict(dict)
-    SUBTABLES: List[Tuple[str, str, bool]] = [
-      ("ANTENNA", "_ant", True),
-      ("DATA_DESCRIPTION", "_ddid", True),
-      ("SPECTRAL_WINDOW", "_spw", True),
-      ("OBSERVATION", "_obs", True),
-      ("POLARIZATION", "_pol", True),
-      ("FEED", "_feed", True),
-      ("FIELD", "_field", False),
-      ("SOURCE", "_source", False),
-      ("STATE", "_state", False),
-    ]
+  def feed_antennas(
+    feed: pa.Table, spw_id: int, feed_ids: List[int]
+  ) -> npt.NDArray[np.int32]:
+    """Returns the unique ANTENNA_ID's associated with
+    the given SPECTRAL_WINDOW_ID and FEED_IDS"""
+    feed_spw_ids = feed["SPECTRAL_WINDOW_ID"].to_numpy()
+    feed_feed_ids = feed["FEED_ID"].to_numpy()
+    antenna_ids = feed["ANTENNA_ID"].to_numpy()
+    mask = np.logical_or(feed_spw_ids == -1, feed_spw_ids == spw_id)
+    np.logical_and(mask, np.isin(feed_feed_ids, feed_ids), out=mask)
+    return np.unique(antenna_ids[mask])
 
-    for subtable_name, attribute, required in SUBTABLES:
-      subtable_path = os.path.join(table_name, subtable_name)
-      if not os.path.exists(subtable_path):
-        if required:
-          raise FileNotFoundError(f"Required subtable {subtable_name} does not exist")
-        else:
-          continue
-
-      with Table.from_filename(
-        f"{table_name}::{subtable_name}", lockoptions="nolock"
-      ) as subtable:
-        subtables[attribute] = subtable.to_arrow()
-        coldescs[subtable_path] = FrozenDict(
-          {
-            c: ColumnDesc.from_descriptor(c, subtable.tabledesc())
-            for c in subtable.columns()
-          }
-        )
-
-    return subtables, coldescs
-
-  def partition_data_factory(
-    self,
-    name: str,
+  @staticmethod
+  def gen_row_interval_grids(
+    time_ids: npt.NDArray[np.int32],
+    antenna1: npt.NDArray[np.int32],
+    antenna2: npt.NDArray[np.int32],
+    intervals: npt.NDArray[np.float64],
+    rows: npt.NDArray[np.int32],
+    row_map: npt.NDArray[np.int64],
+    interval_grid: npt.NDArray[np.float64],
+    feed_antennas: npt.NDArray[npt.int32],
+    na: int,
+    nbl: int,
     auto_corrs: bool,
-    key: PartitionKeyT,
-    value: Dict[str, npt.NDArray],
-    pool: cf.Executor,
-    ncpus: int,
-  ) -> Tuple[PartitionKeyT, PartitionData]:
-    """Generate an updated partition key and
-    `PartitionData` object.
+  ) -> None:
+    """Populate the row map and interval grids"""
+    # Normalise the antenna id's to np.arange(feed_antennas)
+    a1 = np.searchsorted(feed_antennas, antenna1)
+    a2 = np.searchsorted(feed_antennas, antenna2)
+    index = time_ids * nbl
+    index += baseline_id(a1, a2, na, auto_corrs)
+    row_map[index] = rows
+    interval_grid[index] = intervals
 
-    The partition key is updated with subtable partitioning keys
-    (primarily `FIELD.SOURCE_ID` and `STATE.OBSMODE`).
+  @staticmethod
+  def read_subtable(
+    table_name: str,
+    subtable_name: str,
+    missing: Literal["raise", "none"] = "raise",
+    columns: Sequence[str] = (),
+  ) -> pa.Table | None:
+    subtable_path = os.path.join(table_name, subtable_name)
 
-    The `PartitionData` object represents a summary of the
-    partition data passed in via arguments.
-    """
-    time = value["TIME"]
-    interval = value["INTERVAL"]
-    ant1 = value["ANTENNA1"]
-    ant2 = value["ANTENNA2"]
-    rows = value["row"]
-    feed1 = value["FEED1"]
-    feed2 = value["FEED2"]
+    if not os.path.exists(subtable_path):
+      if missing == "raise":
+        raise FileNotFoundError(f"Required subtable {subtable_name} does not exist")
+      else:
+        return None
 
-    # Check that we have a single feed pair which should be the case
-    # as we always partition by DATA_DESC_ID
-    feed1_id = feed1[0].item()
-    feed2_id = feed2[0].item()
+    with Table.from_filename(subtable_path, lockoptions="nolock") as T:
+      return T.to_arrow(columns=list(columns))
 
-    def check_feeds(f1, f2):
-      return np.all(f1 == feed1_id) and np.all(f2 == feed2_id)
-
-    split_feed1 = partition_args(feed1, (feed1.size + ncpus - 1) // ncpus)
-    split_feed2 = partition_args(feed2, (feed2.size + ncpus - 1) // ncpus)
-
-    if not all(pool.map(check_feeds, split_feed1, split_feed2)):
-      ufeed1 = self.par_unique(pool, ncpus, feed1)
-      ufeed2 = self.par_unique(pool, ncpus, feed2)
-      raise PartitioningError(
-        f"Multiple feeds present in partition {key}. "
-        f"FEED1: {ufeed1.tolist()}. "
-        f"FEED2: {ufeed2.tolist()}."
-      )
-
-    if feed1_id != feed2_id:
-      raise NotImplementedError(
-        f"FEED1 != FEED2 ({feed1_id} != {feed2_id}) "
-        f"in partition {key}. Differing FEED ids "
-        f"per DATA_DESC_ID are currently regarded "
-        f"as an edge case of interest. "
-        f"Consider raising a github issue "
-        f"regarding your Measurement Set."
-      )
-
-    # Compute the unique times and their inverse index
-    utime, time_ids = self.par_unique(pool, ncpus, time, return_inverse=True)
-
-    try:
-      ddid = next(int(i) for (c, i) in key if c == "DATA_DESC_ID")
-    except StopIteration:
-      raise KeyError(f"DATA_DESC_ID must be present in partition key {key}")
-    else:
-      if ddid >= len(self._ddid):
-        raise InvalidMeasurementSet(
-          f"DATA_DESC_ID {ddid} does not exist in {name}::DATA_DESCRIPTION"
-        )
-
-    # Extract field and source names
-    field_id = value.get("FIELD_ID")
-    field_names: List[str] = []
-    source_names: List[str] = []
-    line_names: List[str] = []
-
-    if field_id is not None and len(self._field) > 0:
-      ufield_ids = self.par_unique(pool, ncpus, field_id)
-      fields = self._field.take(ufield_ids)
-      field_names = fields["NAME"].to_pylist()
-      source_ids = fields["SOURCE_ID"].to_pylist()
-
-      if "SOURCE_ID" in self._subtable_partition_columns:
-        if len(source_ids) != 1:
-          # We should have partitioned on FIELD_ID
-          raise PartitioningError(
-            f"Multiple FIELD_ID values encountered {ufield_ids} "
-            f"when partitioning on SOURCE_ID requested. "
-            f"FIELD_ID should be present in key {key}."
-          )
-
-        key += (("SOURCE_ID", source_ids[0]),)
-
-      # Select out SOURCES if we have the table
-      if hasattr(self, "_source") and len(self._source) > 0:
-        sources = self._source.take(source_ids)
-        source_names = sources["NAME"].to_pylist()
-        if "TRANSITION" in self._source.column_names:
-          line_names = sources["TRANSITION"].to_pylist()
-
-    # Extract scan numbers
-    scan_number = value.get("SCAN_NUMBER")
-    scan_numbers: List[int] = []
-
-    if scan_number is not None:
-      scan_numbers = self.par_unique(pool, ncpus, scan_number).tolist()
-
-    # Extract intents and sub scan numbers
-    state_id = value.get("STATE_ID")
-    intents: List[str] = []
-    sub_scan_numbers: List[int] = []
-
-    if state_id is not None and len(self._state) > 0:
-      ustate_ids = self.par_unique(pool, ncpus, state_id)
-      states = self._state.take(ustate_ids)
-      intents = states["OBS_MODE"].to_numpy(zero_copy_only=False).tolist()
-      sub_scan_numbers = states["SUB_SCAN"].to_numpy(zero_copy_only=False).tolist()
-
-      if "OBS_MODE" in self._subtable_partition_columns:
-        assert len(intents) == 1
-        key += (("OBS_MODE", intents[0]),)
-
-    # Extract polarization information
-    pol_id = self._ddid["POLARIZATION_ID"][ddid].as_py()
-
-    if pol_id >= len(self._pol):
-      raise InvalidMeasurementSet(
-        f"POLARIZATION_ID {pol_id} does not exist in {name}::POLARIZATION"
-      )
-
-    corr_type = Polarisations.from_values(self._pol["CORR_TYPE"][pol_id].as_py())
-
-    # Extract spectral window information
-    spw_id = self._ddid["SPECTRAL_WINDOW_ID"][ddid].as_py()
-
-    if spw_id >= len(self._spw):
-      raise InvalidMeasurementSet(
-        f"SPECTRAL_WINDOW_ID {spw_id} does not exist in {name}::SPECTRAL_WINDOW"
-      )
-
-    chan_freq = self._spw["CHAN_FREQ"][spw_id].as_py()
-    uchan_width = np.unique(self._spw["CHAN_WIDTH"][spw_id].as_py())
-    spw_name = self._spw["NAME"][spw_id].as_py()
-    spw_freq_group_name = self._spw["FREQ_GROUP_NAME"][spw_id].as_py()
-    spw_ref_freq = self._spw["REF_FREQUENCY"][spw_id].as_py()
-    spw_meas_freq_ref = self._spw["MEAS_FREQ_REF"][spw_id].as_py()
-    spw_frame = FrequencyMeasures(spw_meas_freq_ref).name.lower()
-
-    # Generate the row map and interval grid in parallel
-    row_map = np.full(utime.size * self.nbl, -1.0, dtype=np.int64)
-    interval_grid = np.full(utime.size * self.nbl, -1.0, dtype=np.float64)
-    chunk_size = (len(rows) + ncpus - 1) // ncpus
-
-    def gen_row_map(time_ids, ant1, ant2, ints, rows):
-      assert len(ints) == len(rows) == len(ant1) == len(ant2) == len(time_ids)
-      bl_ids = baseline_id(ant1, ant2, self.na, auto_corrs=auto_corrs)
-      idx = time_ids.copy()
-      idx *= self.nbl
-      idx += bl_ids
-      row_map[idx] = rows
-      interval_grid[idx] = ints
-
-    s = partial(partition_args, chunk=chunk_size)
-    list(pool.map(gen_row_map, s(time_ids), s(ant1), s(ant2), s(interval), s(rows)))
-
-    # In the case of averaged datasets, intervals in the last timestep
-    # may differ from the rest of the interval, remove it and try to find
-    # a unique interval
-    interval_grid = interval_grid.reshape(utime.size, self.nbl)
-
-    if interval_grid.shape[0] > 1:
-      interval_grid = interval_grid[:-1, :]
-
-    uinterval = self.par_unique(pool, ncpus, interval_grid.ravel())
-    uinterval = uinterval[uinterval >= 0]
-
-    try:
-      obs_id = next(int(i) for (c, i) in key if c == "OBSERVATION_ID")
-    except StopIteration:
-      raise KeyError(f"OBSERVATION_ID must be present in partition_key {key}")
-    else:
-      if obs_id >= len(self._obs):
-        raise InvalidMeasurementSet(
-          f"OBSERVATION_ID {obs_id} does not exist in {name}::OBSERVATION"
-        )
-
-    obs = self._obs.take([obs_id])
-    telescope_name = obs["TELESCOPE_NAME"].to_numpy().item()
-    observer = obs["OBSERVER"].to_numpy().item()
-    project = obs["PROJECT"].to_numpy().item()
-    # TODO(sjperkins). Do a proper measures conversion
-    release_date = datetime.now(timezone.utc).isoformat()
-
-    partition_data = PartitionData(
-      time=utime,
-      interval=uinterval,
-      chan_freq=chan_freq,
-      chan_width=uchan_width,
-      corr_type=corr_type.to_str(),
-      intents=intents,
-      field_names=field_names,
-      line_names=line_names,
-      source_names=source_names,
-      feed_id=feed1_id,
-      spw_id=spw_id,
-      spw_name=spw_name,
-      spw_freq_group_name=spw_freq_group_name,
-      spw_ref_freq=spw_ref_freq,
-      spw_frame=spw_frame,
-      row_map=row_map.reshape(utime.size, self.nbl),
-      scan_numbers=scan_numbers,
-      sub_scan_numbers=sub_scan_numbers,
-      telescope_name=telescope_name,
-      observer=observer,
-      project=project,
-      release_date=release_date,
-    )
-
-    return tuple(sorted(key)), partition_data
+  @property
+  def ms_factory(self) -> TableFactory:
+    return self._ms_factory
 
   def __init__(
     self, ms: TableFactory, partition_schema: List[str], auto_corrs: bool = True
@@ -824,21 +658,21 @@ class MSv2Structure(Mapping):
     self._ms_factory = ms
     self._partition_columns = partition_columns
     self._subtable_partition_columns = subtable_columns
-    self._auto_corrs = auto_corrs
 
     ms_table = ms()
-    name = ms_table.name()
-    table_desc = ms_table.tabledesc()
-    subtables, coldescs = self.read_subtables(name)
+    ms_name = ms_table.name()
 
-    for a, subtable in subtables.items():
-      setattr(self, a, subtable)
-
-    coldescs["MAIN"] = FrozenDict(
-      {c: ColumnDesc.from_descriptor(c, table_desc) for c in ms_table.columns()}
-    )
-
-    self._column_descs = FrozenDict(coldescs)
+    try:
+      data_description: pa.Table = self.read_subtable(ms_name, "DATA_DESCRIPTION")
+      feed = self.read_subtable(
+        ms_name, "FEED", columns=["ANTENNA_ID", "FEED_ID", "SPECTRAL_WINDOW_ID"]
+      )
+      state = self.read_subtable(ms_name, "STATE", columns=["SUB_SCAN", "OBS_MODE"])
+      field = self.read_subtable(ms_name, "FIELD", columns=["SOURCE_ID"])
+    except FileNotFoundError as e:
+      raise InvalidMeasurementSet(
+        "Measurement Set is missing a required subtable"
+      ) from e
 
     other_columns = ["FEED1", "FEED2", "INTERVAL"]
     read_columns = (
@@ -848,21 +682,154 @@ class MSv2Structure(Mapping):
 
     ncpus = mp.cpu_count()
     with cf.ThreadPoolExecutor(max_workers=ncpus) as pool:
-      source_id = self.maybe_get_source_id(
-        pool, ncpus, arrow_table["FIELD_ID"].to_numpy()
-      )
-      if source_id is not None:
-        arrow_table = arrow_table.append_column("SOURCE_ID", source_id[None, :])
 
+      def subtable_column_group(s):
+        """Return the group that the subtable column should be assigned to"""
+        return partition_columns if s in subtable_columns else other_columns
+
+      def get_uid_column(column, dkey, ids) -> List[Any]:
+        """Get the unique values for the given column, preferably from the
+        partition key or failing that, from `ids`. Generally should be used with
+        ID columns"""
+        try:
+          return [dkey[column]]
+        except KeyError:
+          return self.par_unique(pool, ncpus, ids).tolist()
+
+      # Broadcast and add FIELD.SOURCE_ID column
+      field_id = arrow_table["FIELD_ID"].to_numpy()
+      source_id = self.broadcast_source_id(pool, ncpus, field, field_id)
+      arrow_table = arrow_table.append_column("SOURCE_ID", source_id[None, :])
+      subtable_column_group("SOURCE_ID").append("SOURCE_ID")
+
+      # Broadcast and add STATE.OBS_MODE and STATE.SUB_SCAN_NUMBER columns
+      state_id = arrow_table["STATE_ID"].to_numpy()
+      obs_mode_id, om_to_sid_map = self.broadcast_obsmode_id(
+        pool, ncpus, state, state_id
+      )
+      subscan_nr = self.broadcast_sub_scan_number(pool, ncpus, state, state_id)
+      arrow_table = arrow_table.append_column("OBS_MODE_ID", obs_mode_id[None, :])
+      arrow_table = arrow_table.append_column("SUB_SCAN_NUMBER", subscan_nr[None, :])
+      subtable_column_group("SUB_SCAN_NUMBER").append("SUB_SCAN_NUMBER")
+      # Substitute OBS_MODE for OBS_MODE_ID
+      partition_columns.append("OBS_MODE_ID")
+
+      # Perform partitioning
       partitions = TablePartitioner(
         partition_columns, SORT_COLUMNS, other_columns + ["row"]
       ).partition(arrow_table, pool)
+
+      # Generate a PartitionData variable per partition
       self._partitions = {}
 
-      for k, v in partitions.items():
-        key, partition = self.partition_data_factory(
-          name, auto_corrs, k, v, pool, ncpus
-        )
-        self._partitions[key] = partition
+      for key, partition in partitions.items():
+        dkey = dict(key)
 
-    logger.info("Reading %s structure in took %fs", name, modtime.time() - start)
+        # The following should always be part of the partioning key
+        try:
+          ddid = int(dkey["DATA_DESC_ID"])
+          obs_id = int(dkey["OBSERVATION_ID"])
+          obs_mode_id = int(dkey.pop("OBS_MODE_ID"))
+        except KeyError as e:
+          raise KeyError(f"{e} must be present in partition key {key}")
+
+        dkey["OBS_MODE"] = tuple(om_to_sid_map.keys())[obs_mode_id]
+
+        if ddid >= len(data_description):
+          raise InvalidMeasurementSet(
+            f"DATA_DESC_ID {ddid} does not exist in {ms_name}::DATA_DESCRIPTION"
+          )
+
+        spw_id = data_description["SPECTRAL_WINDOW_ID"][ddid].as_py()
+        pol_id = data_description["POLARIZATION_ID"][ddid].as_py()
+        antenna1 = partition["ANTENNA1"]
+        antenna2 = partition["ANTENNA2"]
+        interval = partition["INTERVAL"]
+        rows = partition["row"]
+        chunk = (len(rows) + ncpus - 1) // ncpus
+
+        # Unique partition key values
+        ufield_ids = get_uid_column("FIELD_ID", dkey, partition["FIELD_ID"])
+        usubscan_nrs = get_uid_column(
+          "SUB_SCAN_NUMBER", dkey, partition["SUB_SCAN_NUMBER"]
+        )
+        uscan_nrs = get_uid_column("SCAN_NUMBER", dkey, partition["SCAN_NUMBER"])
+        ustate_ids = get_uid_column("STATE_ID", dkey, partition["STATE_ID"])
+        usource_ids = get_uid_column("SOURCE_ID", dkey, partition["SOURCE_ID"])
+
+        # Unique sorting/other column values
+        utime, time_ids = self.par_unique(
+          pool, ncpus, partition["TIME"], return_inverse=True
+        )
+        uantenna1 = self.par_unique(pool, ncpus, antenna1)
+        uantenna2 = self.par_unique(pool, ncpus, antenna2)
+        uantennas = np.union1d(uantenna1, uantenna2)
+        ufeed1s = self.par_unique(pool, ncpus, partition["FEED1"])
+        ufeed2s = self.par_unique(pool, ncpus, partition["FEED2"])
+        ufeeds = np.union1d(ufeed1s, ufeed2s)
+
+        # Query the FEED table to discover all canonical
+        # antennas in this partition
+        feed_antennas = self.feed_antennas(feed, spw_id, ufeeds)
+        if not np.all(np.isin(uantennas, feed_antennas)):
+          raise InvalidMeasurementSet(
+            f"Unique ANTENNA1 and ANTENNA2 values {uantennas} "
+            f"are not a subset of FEED::ANTENNA_ID {feed_antennas} "
+            f"for SPECTRAL_WINDOW_ID={spw_id} and feeds={ufeeds}"
+          )
+
+        na = len(feed_antennas)
+        nbl = nr_of_baselines(na, auto_corrs)
+
+        # Populate row map and interval grids
+        row_map = np.full(utime.size * nbl, -1, dtype=np.int64)
+        interval_grid = np.full(utime.size * nbl, -1.0, dtype=np.float64)
+
+        list(
+          pool.map(
+            partial(
+              self.gen_row_interval_grids,
+              row_map=row_map,
+              interval_grid=interval_grid,
+              feed_antennas=feed_antennas,
+              na=na,
+              nbl=nbl,
+              auto_corrs=auto_corrs,
+            ),
+            partition_args(time_ids, chunk),
+            partition_args(antenna1, chunk),
+            partition_args(antenna2, chunk),
+            partition_args(interval, chunk),
+            partition_args(rows, chunk),
+          )
+        )
+
+        # In the case of averaged datasets, intervals in the last timestep
+        # may differ from other intervals. Remove it and try to find
+        # a unique interval
+        interval_grid = interval_grid.reshape(utime.size, nbl)
+
+        if interval_grid.shape[0] > 1:
+          interval_grid = interval_grid[:-1, :]
+
+        uinterval = self.par_unique(pool, ncpus, interval_grid.ravel())
+        uinterval = uinterval[uinterval >= 0]
+
+        self._partitions[tuple(sorted(dkey.items()))] = PartitionData(
+          time=utime,
+          interval=uinterval,
+          obs_id=obs_id,
+          spw_id=spw_id,
+          pol_id=pol_id,
+          antenna_ids=feed_antennas.tolist(),
+          feed_ids=ufeeds.tolist(),
+          field_ids=ufield_ids,
+          scan_numbers=uscan_nrs,
+          source_ids=usource_ids,
+          state_ids=ustate_ids,
+          obs_mode=str(dkey["OBS_MODE"]),
+          sub_scan_numbers=usubscan_nrs,
+          row_map=row_map.reshape(utime.size, nbl),
+        )
+
+    logger.info("Reading %s structure in took %fs", ms_name, modtime.time() - start)

--- a/xarray_ms/backend/msv2/structure.py
+++ b/xarray_ms/backend/msv2/structure.py
@@ -99,15 +99,6 @@ def baseline_id(
   return result
 
 
-def is_partition_key(key: PartitionKeyT) -> bool:
-  return (
-    isinstance(key, tuple)
-    and len(key) == 2
-    and isinstance(key[0], str)
-    and isinstance(key[1], int)
-  )
-
-
 def partition_args(data: npt.NDArray, chunk: int) -> List[npt.NDArray]:
   return [data[i : i + chunk] for i in range(0, len(data), chunk)]
 


### PR DESCRIPTION
Prior to this change, the partioning logic had evolved somewhat organically, become brittle and duplicating logic. In particular the MSV2Structure class was evolving towards a god class that performed partioning, as well as extracting metadata out of subtables.

This commit refactors MSv2Structure to primarily perform partioning logic and expose the results of this partitioning.

Responsbility for populating dataset metadata is now offloaded to dataset factory classes.

Additionally, the FEED table is now used to establish the canonical set of ANTENNA's that apply to a partition, rather than the entire ANTENNA table.

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->


- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--78.org.readthedocs.build/en/78/

<!-- readthedocs-preview xarray-ms end -->