### PR TITLE
Use creator attribute to record xarray-ms version

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Use creator attribute to record xarray-ms version (:pr:`80`)
 * Generalise the TableFactory class into a Multiton class (:pr:`79`)
 * Refactor partitioning logic to be more robust (:pr:`78`)
 * The set of ANTENNA's related to a partition in the FEED table is

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -251,7 +251,10 @@ class MSv2Store(AbstractWritableDataStore):
       "schema_version": "4.0.0",
       "creation_date": datetime.now(timezone.utc).isoformat(),
       "type": "visibility",
-      "xarray_ms_version": importlib_version("xarray-ms"),
+      "creator": {
+        "software_name": "xarray-ms",
+        "version": importlib_version("xarray-ms"),
+      },
     }
 
     return dict(sorted({**attrs, **factory.get_attrs()}.items()))


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->


- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--80.org.readthedocs.build/en/80/

<!-- readthedocs-preview xarray-ms end -->