### PR TITLE
Ensure resources are correctly released when datasets/datatrees are closed

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Release resources when datasets or datatrees are closed (:pr:`81`)
 * Use creator attribute to record xarray-ms version (:pr:`80`)
 * Generalise the TableFactory class into a Multiton class (:pr:`79`)
 * Refactor partitioning logic to be more robust (:pr:`78`)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -5,7 +5,6 @@ import pytest
 import xarray
 import xarray.testing as xt
 from numpy.testing import assert_array_equal
-from xarray.backends.api import open_datatree
 
 from xarray_ms.backend.msv2.entrypoint import MSv2EntryPoint
 from xarray_ms.testing.utils import id_string
@@ -148,7 +147,7 @@ def test_open_datatree(simmed_ms):
 
   # Works with xarray default load mechanism
   with ExitStack() as stack:
-    mem_dt = open_datatree(simmed_ms)
+    mem_dt = stack.enter_context(xarray.open_datatree(simmed_ms))
     mem_dt.load()
     for node in mem_dt.subtree:
       if node.attrs.get("type") == "visibility":
@@ -159,7 +158,7 @@ def test_open_datatree(simmed_ms):
 
   # Works with default dask scheduler
   with ExitStack() as stack:
-    dt = open_datatree(simmed_ms, preferred_chunks=chunks)
+    dt = stack.enter_context(xarray.open_datatree(simmed_ms, preferred_chunks=chunks))
     for node in dt.subtree:
       if node.attrs.get("type") == "visibility":
         del node.attrs["creation_date"]
@@ -169,7 +168,7 @@ def test_open_datatree(simmed_ms):
   with ExitStack() as stack:
     cluster = stack.enter_context(LocalCluster(processes=True, n_workers=4))
     stack.enter_context(Client(cluster))
-    dt = open_datatree(simmed_ms, preferred_chunks=chunks)
+    dt = stack.enter_context(xarray.open_datatree(simmed_ms, preferred_chunks=chunks))
     for node in dt.subtree:
       if node.attrs.get("type") == "visibility":
         del node.attrs["creation_date"]
@@ -189,7 +188,7 @@ def test_open_datatree(simmed_ms):
 def test_open_datatree_chunking(simmed_ms):
   """Test opening a datatree with both uniform
   and partition-specific chunking"""
-  dt = open_datatree(
+  dt = xarray.open_datatree(
     simmed_ms,
     chunks={},
     preferred_chunks={"time": 3, "frequency": 2},
@@ -211,7 +210,7 @@ def test_open_datatree_chunking(simmed_ms):
     "uvw_label": (3,),
   }
 
-  dt = open_datatree(
+  dt = xarray.open_datatree(
     simmed_ms,
     chunks={},
     preferred_chunks={

--- a/tests/test_multiton.py
+++ b/tests/test_multiton.py
@@ -1,12 +1,11 @@
 import pickle
 
-import pytest
+import xarray
 from arcae.lib.arrow_tables import Table
 
 from xarray_ms.multiton import Multiton
 
 
-@pytest.mark.parametrize("simmed_ms", [{"name": "proxy.ms"}], indirect=True)
 def test_multiton_duplicate_args(simmed_ms):
   """Tests that when opened with duplicate arguments,
   the same Multiton is returned"""
@@ -49,7 +48,15 @@ def test_multiton_release():
   assert data["closed"] is True
 
 
-@pytest.mark.parametrize("simmed_ms", [{"name": "proxy.ms"}], indirect=True)
+def test_multiton_datatree_release(simmed_ms):
+  assert len(Multiton._INSTANCE_CACHE) == 0
+
+  with xarray.open_datatree(simmed_ms):
+    assert len(Multiton._INSTANCE_CACHE) > 0
+
+  assert len(Multiton._INSTANCE_CACHE) == 0
+
+
 def test_multiton_pickling(simmed_ms):
   """Test that a pickle roundtrip of the Multiton results in the same object"""
 

--- a/xarray_ms/backend/msv2/main_dataset_factory.py
+++ b/xarray_ms/backend/msv2/main_dataset_factory.py
@@ -1,6 +1,6 @@
 import dataclasses
 import warnings
-from typing import Any, Dict, Mapping, Tuple, Type
+from typing import Any, Dict, List, Mapping, Tuple, Type
 
 import numpy as np
 from xarray import Variable
@@ -18,6 +18,8 @@ from xarray_ms.backend.msv2.structure import MSv2StructureFactory, PartitionKeyT
 from xarray_ms.casa_types import ColumnDesc, FrequencyMeasures, Polarisations
 from xarray_ms.errors import IrregularGridWarning
 from xarray_ms.multiton import Multiton
+
+MAIN_DATASET_TYPES: List[str] = ["visibility", "spectrum", "wvr"]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--81.org.readthedocs.build/en/81/

<!-- readthedocs-preview xarray-ms end -->