### PR TITLE
Use missing structure_factory argument in open_groups_as_dict

### DIFF
--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -417,7 +417,7 @@ class MSv2EntryPoint(BackendEntrypoint):
       preferred_chunks,
       None,
       None,
-      None,
+      structure_factory,
     )
 
     # /path/to/some_name.ext -> some_name


### PR DESCRIPTION

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.
