### PR TITLE
Allow a degree of jitter in INTERVAL/INTEGRATION_TIME values

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Allow some jitter in the `INTERVAL` column when setting `time.integration_time` (:pr:`93`)
 * Impute missing `FIELD`, `STATE` and `OBSERVATION` subtable data (:pr:`92`)
 * Increase MSv2Structure cache timeout from 1 to 5 minutes (:pr:`91`)
 * Check for TIME and INTEGRATION_TIME in the case of multiple INTERVAL values (:pr:`90`)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -211,6 +211,40 @@ def test_differing_start_intervals(simmed_ms):
     assert "INTEGRATION_TIME" in node.data_vars
 
 
+DUMP_RATE = 8.0
+
+
+def _jitter_intervals(chunk_desc, data_dict):
+  """Jitter the INTERVAL column"""
+  interval = data_dict["INTERVAL"][-1]
+  assert np.all(interval == DUMP_RATE)
+  rng = np.random.default_rng()
+  interval[:] += rng.standard_normal(interval.shape, interval.dtype) * 1e-6
+  return data_dict
+
+
+@pytest.mark.parametrize(
+  "simmed_ms",
+  [
+    {
+      "name": "backend.ms",
+      "dump_rate": DUMP_RATE,
+      "data_description": [(8, ["XX", "XY", "YX", "YY"]), (4, ["RR", "LL"])],
+      "transform_data": _jitter_intervals,
+    }
+  ],
+  indirect=True,
+)
+def test_jittered_intervals(simmed_ms):
+  """Test that intervals with very small differences results using their mean"""
+  xdt = xarray.open_datatree(simmed_ms, auto_corrs=True)
+
+  for p in ["000", "001"]:
+    node = xdt[f"backend_partition_{p}"]
+    assert np.isclose(node.time.integration_time, DUMP_RATE)
+    print(node.time.integration_time)
+
+
 def _remove_weight_spectrum_add_weight(chunk_desc, data_dict):
   data_dict = data_dict.copy()
   del data_dict["WEIGHT_SPECTRUM"]

--- a/xarray_ms/backend/msv2/factories/correlated.py
+++ b/xarray_ms/backend/msv2/factories/correlated.py
@@ -260,8 +260,14 @@ class CorrelatedDatasetFactory:
     time_coder = TimeCoder("TIME", self._main_column_descs)
 
     if partition.interval.size == 1:
+      # Single unique values
       time_attrs = {"integration_time": partition.interval.item()}
+    elif np.allclose(partition.interval[:, None], partition.interval[None, :]):
+      # Tolerate some jitter in the unique values
+      time_attrs = {"integration_time": np.mean(partition.interval)}
     else:
+      # There are multiple unique interval values,
+      # a regular grid isn't possible
       warnings.warn(
         f"Missing/Multiple intervals {partition.interval} "
         f"found in partition {self._partition_key}. "

--- a/xarray_ms/backend/msv2/factories/correlated.py
+++ b/xarray_ms/backend/msv2/factories/correlated.py
@@ -260,7 +260,7 @@ class CorrelatedDatasetFactory:
     time_coder = TimeCoder("TIME", self._main_column_descs)
 
     if partition.interval.size == 1:
-      # Single unique values
+      # Single unique value
       time_attrs = {"integration_time": partition.interval.item()}
     elif np.allclose(partition.interval[:, None], partition.interval[None, :]):
       # Tolerate some jitter in the unique values


### PR DESCRIPTION
INTERVAL column values can be close to within a tolerance. If so, use their mean to set `time.integration_time`

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->



- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--93.org.readthedocs.build/en/93/

<!-- readthedocs-preview xarray-ms end -->