### PR TITLE
Upgrade to arcae 0.2.9 to elide selection checks on ignored rows

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+0.3.0 (10-06-2025)
+------------------
+* Upgrade to arcae 0.2.9 to elide selection checks on ignored rows (:pr:`105`)
+
 0.2.9 (02-06-2025)
 ------------------
 * Handle negative foreign keys during imputation of subtables (:pr:`102`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ xarray = "^2025.0"
 dask = {version = "^2024.5.0", optional = true, extras = ["testing"]}
 distributed = {version = "^2024.5.0", optional = true, extras = ["testing"]}
 cacheout = "^0.16.0"
-arcae = "^0.2.8"
+arcae = "^0.2.9"
 typing-extensions = { version = "^4.12.2", python = "<3.11" }
 zarr = {version = "^2.18.3", optional = true, extras = ["testing"]}
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -188,6 +188,14 @@ def test_open_datatree(simmed_ms):
 def test_open_datatree_chunking(simmed_ms):
   """Test opening a datatree with both uniform
   and partition-specific chunking"""
+
+  ncdt = xarray.open_datatree(simmed_ms, auto_corrs=True)
+  ncdt.load()
+
+  # Remove attributes that would break xarray.identical
+  for p in range(len(ncdt.children)):
+    del ncdt[f"backend_partition_{p:03}"].attrs["creation_date"]
+
   dt = xarray.open_datatree(
     simmed_ms,
     auto_corrs=True,
@@ -210,6 +218,12 @@ def test_open_datatree_chunking(simmed_ms):
     "polarization": (2,),
     "uvw_label": (3,),
   }
+
+  # Remove attributes that would break xarray.identical
+  for p in range(len(ncdt.children)):
+    del dt[f"backend_partition_{p:03}"].attrs["creation_date"]
+
+  assert ncdt.identical(dt)
 
   dt = xarray.open_datatree(
     simmed_ms,
@@ -235,3 +249,9 @@ def test_open_datatree_chunking(simmed_ms):
     "polarization": (2,),
     "uvw_label": (3,),
   }
+
+  # Remove attributes that would break xarray.identical
+  for p in range(len(ncdt.children)):
+    del dt[f"backend_partition_{p:03}"].attrs["creation_date"]
+
+  assert ncdt.identical(dt)


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose


Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Closes #104 

arcae 0.2.9 includes a fix that prevents selection checks against a row shape for ignored rows.

- https://github.com/ratt-ru/arcae/pull/154

This PR:

1. upgrades xarray-ms' arcae dependency to 0.2.9
2. strengthens the `preferred_chunks` test case to confirm that `xarray.identical(dt.load(), dt.compute())` holds. This was the case with arcae 0.2.8 but this is now checked.


<!-- empty -->

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--105.org.readthedocs.build/en/105/

<!-- readthedocs-preview xarray-ms end -->