### PR TITLE
Fix low-resolution broadcasting

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+0.3.1 (11-06-2025)
+------------------
+* Fix low-resolution broadcasting (:pr:`106`)
+
 0.3.0 (10-06-2025)
 ------------------
 * Upgrade to arcae 0.2.9 to elide selection checks on ignored rows (:pr:`105`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dask = {version = "^2024.5.0", optional = true, extras = ["testing"]}
 distributed = {version = "^2024.5.0", optional = true, extras = ["testing"]}
 cacheout = "^0.16.0"
 arcae = "^0.2.9"
-typing-extensions = { version = "^4.12.2", python = "<3.11" }
+typing-extensions = "^4.12.2"
 zarr = {version = "^2.18.3", optional = true, extras = ["testing"]}
 
 [tool.poetry.extras]


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

The original low-resolution broadcast code failed on selections of the data. 

- #58 

This PR corrects this.

<!-- -->

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--106.org.readthedocs.build/en/106/

<!-- readthedocs-preview xarray-ms end -->