### PR TITLE
Call MSv2Array.__getitem__ rather than MSv2Array._getitem which is not guaranteed to be present

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Call MSv2Array.__getitem__ rather than MSv2Array._getitem which is not guaranteed to be present (:pr:`107`)
+
 0.3.1 (11-06-2025)
 ------------------
 * Fix low-resolution broadcasting (:pr:`106`)

--- a/xarray_ms/backend/msv2/array.py
+++ b/xarray_ms/backend/msv2/array.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING, Any, Callable, Tuple
 
 import numpy as np
 from xarray.backends import BackendArray
-from xarray.core.indexing import IndexingSupport, explicit_indexing_adapter
+from xarray.core.indexing import (
+  IndexingSupport,
+  OuterIndexer,
+  explicit_indexing_adapter,
+)
 
 if TYPE_CHECKING:
   import numpy.typing as npt
@@ -178,6 +182,6 @@ class BroadcastMSv2Array(MSv2Array):
     if reduce(mul, expected_shape, 1) == 0:
       return np.empty(expected_shape, dtype=self.dtype)
     low_res_key = tuple(k for i, k in zip(self._low_res_index, key) if i is not None)
-    low_res_data = self._low_res_array._getitem(low_res_key)
+    low_res_data = self._low_res_array.__getitem__(OuterIndexer(low_res_key))
     low_res_data = low_res_data[self._low_res_index]
     return np.broadcast_to(low_res_data, expected_shape)


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--107.org.readthedocs.build/en/107/

<!-- readthedocs-preview xarray-ms end -->