### PR TITLE
Correct clamp of the slice stop to be min(shape[d], s.stop)

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Correct clamp of the slice stop to be min(shape[d], s.stop) (:pr:`115`)
 * Rename deprecated ``repository_url`` to ``repository-url`` (:pr:`112`)
 * Use trusted publishing when publishing to pypi (:pr:`111`)
 * Update pre-commit hooks (:pr:`110`)

--- a/xarray_ms/backend/msv2/array.py
+++ b/xarray_ms/backend/msv2/array.py
@@ -27,7 +27,7 @@ def slice_length(s: npt.NDArray | slice, max_len) -> int:
       raise NotImplementedError("Slicing with non-1D numpy arrays")
     return len(s)
 
-  start, stop, step = s.indices(max_len)
+  start, stop, step = s.indices(min(max_len, s.stop) if s.stop is not None else max_len)
   if step != 1:
     raise NotImplementedError(f"Slicing with steps {s} other than 1 not supported")
   return stop - start


### PR DESCRIPTION
When retrieving data from CASA, clamp the output array length to min(shape[d], s.stop)

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [ ] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--115.org.readthedocs.build/en/115/

<!-- readthedocs-preview xarray-ms end -->