### PR TITLE
Correct MSv4 schema issues

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Correct basic schema issues (:pr:`125`)
 * Support TAI Measure encoding in time data (:pr:`124`)
 * Distinguish between time, baseline and channel irregularity (:pr:`123`)
 * Test xarray-ms against the full MSv4 Test Corpus (:pr:`120`)

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
-* Correct basic schema issues (:pr:`125`)
+* Correct MSv4 schema issues (:pr:`125`)
 * Support TAI Measure encoding in time data (:pr:`124`)
 * Distinguish between time, baseline and channel irregularity (:pr:`123`)
 * Test xarray-ms against the full MSv4 Test Corpus (:pr:`120`)

--- a/tests/msv4_test_corpus/test_msv_corpus.py
+++ b/tests/msv4_test_corpus/test_msv_corpus.py
@@ -9,6 +9,7 @@ pmx = pytest.mark.xfail
 
 
 @pytest.mark.msv4_test_corpus
+@pytest.mark.filterwarnings("ignore::xarray_ms.errors.FrameConversionWarning")
 @pytest.mark.filterwarnings("ignore::xarray_ms.errors.ImputedMetadataWarning")
 @pytest.mark.filterwarnings("ignore::xarray_ms.errors.IrregularTimeGridWarning")
 @pytest.mark.filterwarnings("ignore::xarray_ms.errors.IrregularBaselineGridWarning")

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -31,7 +31,7 @@ def test_utc_time_encoder_roundtrip(mjd, utc):
   """Test conversion of Modified Julian Date
   to UTC in seconds, and vice versa"""
 
-  time_coder = TimeCoder("TIME", COLUMN_DESCS)
+  time_coder = TimeCoder(COLUMN_DESCS["TIME"])
   time = Variable(("dummy",), np.array([mjd * SECONDS_IN_DAY]))
   decoded_time = time_coder.decode(time)
   utc_seconds = decoded_time.values[0]

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -38,7 +38,7 @@ def test_utc_time_encoder_roundtrip(mjd, utc):
   assert utc == datetime.fromtimestamp(utc_seconds, timezone.utc)
   assert decoded_time.attrs == {
     "type": "time",
-    "units": ["s"],
+    "units": "s",
     "scale": "utc",
     "format": "unix",
   }

--- a/tests/test_field_and_source.py
+++ b/tests/test_field_and_source.py
@@ -11,9 +11,11 @@ def test_field_and_source(simmed_ms):
   dt = dt.load()
 
   p0 = dt["test_partition_000"]
-  field_source = p0["field_and_source_xds"]
-  assert field_source.field_name == ["FIELD-0"]
-  assert field_source.source_name == ["SOURCE-0"]
-  np.testing.assert_array_equal(
-    field_source.FIELD_PHASE_CENTER_DIRECTION.values, [[0, 0]]
-  )
+
+  for _, data_group in p0.attrs.get("data_group", {}).items():
+    field_source = data_group["field_and_source"]
+    assert field_source.field_name == ["FIELD-0"]
+    assert field_source.source_name == ["SOURCE-0"]
+    np.testing.assert_array_equal(
+      field_source.FIELD_PHASE_CENTER_DIRECTION.values, [[0, 0]]
+    )

--- a/tests/test_imputation.py
+++ b/tests/test_imputation.py
@@ -22,7 +22,11 @@ def test_imputed_observation_metadata(simmed_ms):
   ):
     for node in xarray.open_datatree(simmed_ms).subtree:
       if node.attrs.get("type") in CORRELATED_DATASET_TYPES:
-        assert node.observation_info == {"observer": "unknown", "project": "unknown"}
+        assert node.observation_info == {
+          "observer": ["unknown"],
+          "project": "unknown",
+          "intents": ["CALIBRATE_AMPL#OFF_SOURCE"],
+        }
 
 
 @pytest.mark.filterwarnings("ignore::xarray_ms.errors.ImputedMetadataWarning")

--- a/tests/test_imputation.py
+++ b/tests/test_imputation.py
@@ -26,6 +26,7 @@ def test_imputed_observation_metadata(simmed_ms):
           "observer": ["unknown"],
           "project": "unknown",
           "intents": ["CALIBRATE_AMPL#OFF_SOURCE"],
+          "release_date": "1978-10-09T08:00:00+00:00",
         }
 
 

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -181,7 +181,7 @@ def test_differing_trailing_intervals(simmed_ms):
 
   for p in ["000", "001"]:
     node = xdt[f"backend_partition_{p}"]
-    assert node.time.attrs["integration_time"] == 8.0
+    assert node.time.integration_time["data"] == 8.0
 
 
 def _randomise_starting_intervals(chunk_desc, data_dict):
@@ -212,7 +212,7 @@ def test_differing_start_intervals(simmed_ms):
 
   for p in ["000", "001"]:
     node = xdt[f"backend_partition_{p}"]
-    assert np.isnan(node.time.attrs["integration_time"])
+    assert np.isnan(node.time.integration_time["data"])
     assert "TIME" in node.data_vars
     assert "INTEGRATION_TIME" in node.data_vars
 
@@ -248,7 +248,7 @@ def test_jittered_intervals(simmed_ms):
 
   for p in ["000", "001"]:
     node = xdt[f"backend_partition_{p}"]
-    assert np.isclose(node.time.integration_time, DUMP_RATE)
+    assert np.isclose(node.time.integration_time["data"], DUMP_RATE)
 
 
 def _remove_weight_spectrum_add_weight(chunk_desc, data_dict):

--- a/xarray_ms/backend/msv2/encoders.py
+++ b/xarray_ms/backend/msv2/encoders.py
@@ -184,7 +184,7 @@ class TimeCoder(CasaCoder):
     elif ref == "TAI":
       cls = TAICoder
     else:
-      raise NotImplementedError(measures["Ref"])
+      raise NotImplementedError(f"Epoch frame {measures['Ref']}")
 
     return cls.from_time_coder(self)
 

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -421,18 +421,15 @@ class MSv2EntryPoint(BackendEntrypoint):
         # We may need to fix the UVW frame if it's set to ITRF
         if (uvw_attrs := dataset.UVW.attrs)["frame"] == "ITRF":
           frame = field_and_source.FIELD_PHASE_CENTER_DIRECTION.attrs["frame"]
-          # TODO: ITRF is the default UVW frame anyway so suppress it for now
-          # and hope for an ITRF -> ITRS conversion
-          # https://github.com/casangi/xradio/issues/476
-          with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=FrameConversionWarning)
-            warnings.warn(
-              f"UVW coordinate frame was set to ITRF which is "
-              f"a currently unsupported frame within the MSv4 schema. "
-              f"Setting to {frame} from the FIELD_PHASE_CENTER_DIRECTION "
-              f"of the field associated with this dataset.",
-              FrameConversionWarning,
-            )
+          warnings.warn(
+            f"UVW coordinate frame was set to ITRF which is "
+            f"an unsupported MSv4 frame for UVW. "
+            f"Setting the frame to {frame} from the "
+            f"FIELD_PHASE_CENTER_DIRECTION of the field "
+            f"associated with this dataset. "
+            f"See https://github.com/casangi/xradio/issues/476",
+            FrameConversionWarning,
+          )
           uvw_attrs["frame"] = frame
 
   @format_docstring(DEFAULT_PARTITION_COLUMNS=DEFAULT_PARTITION_COLUMNS)

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -25,7 +25,7 @@ from xarray_ms.backend.msv2.structure import (
   MSv2Structure,
   MSv2StructureFactory,
 )
-from xarray_ms.errors import InvalidPartitionKey
+from xarray_ms.errors import FrameConversionWarning, InvalidPartitionKey
 from xarray_ms.msv4_types import CORRELATED_DATASET_TYPES
 from xarray_ms.multiton import Multiton
 from xarray_ms.utils import format_docstring
@@ -418,9 +418,22 @@ class MSv2EntryPoint(BackendEntrypoint):
             }
           }
 
-        # We may need to fix the UVW frame
-        if (uvw_attrs := dataset.UVW.attrs).get("frame") == "ITRF":
-          uvw_attrs["frame"] = "fk5"
+        # We may need to fix the UVW frame if it's set to ITRF
+        if (uvw_attrs := dataset.UVW.attrs)["frame"] == "ITRF":
+          frame = field_and_source.FIELD_PHASE_CENTER_DIRECTION.attrs["frame"]
+          # TODO: ITRF is the default UVW frame anyway so suppress it for now
+          # and hope for an ITRF -> ITRS conversion
+          # https://github.com/casangi/xradio/issues/476
+          with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FrameConversionWarning)
+            warnings.warn(
+              f"UVW coordinate frame was set to ITRF which is "
+              f"a currently unsupported frame within the MSv4 schema. "
+              f"Setting to {frame} from the FIELD_PHASE_CENTER_DIRECTION "
+              f"of the field associated with this dataset.",
+              FrameConversionWarning,
+            )
+          uvw_attrs["frame"] = frame
 
   @format_docstring(DEFAULT_PARTITION_COLUMNS=DEFAULT_PARTITION_COLUMNS)
   def open_groups_as_dict(

--- a/xarray_ms/backend/msv2/factories/antenna.py
+++ b/xarray_ms/backend/msv2/factories/antenna.py
@@ -112,7 +112,7 @@ class AntennaFactory(DatasetFactory):
       coords={
         "antenna_name": Variable("antenna_name", antenna_names),
         "mount": Variable("antenna_name", mount),
-        "telescope_name": Variable("telescope_name", telescope_names),
+        "telescope_name": Variable("antenna_name", telescope_names),
         "station_name": Variable("antenna_name", station),
         "cartesian_pos_label": Variable("cartesian_pos_label", ["x", "y", "z"]),
         "polarization_type": Variable(("antenna_name", "receptor_label"), pol_type),

--- a/xarray_ms/backend/msv2/factories/antenna.py
+++ b/xarray_ms/backend/msv2/factories/antenna.py
@@ -90,6 +90,9 @@ class AntennaFactory(DatasetFactory):
         {
           "coordinate_system": "geocentric",
           "origin_object_name": "earth",
+          "type": "location",
+          "frame": "ITRS",
+          "units": "m",
         },
       ),
       "ANTENNA_DISH_DIAMETER": Variable("antenna_name", diameter, metre_attrs),

--- a/xarray_ms/backend/msv2/factories/antenna.py
+++ b/xarray_ms/backend/msv2/factories/antenna.py
@@ -51,12 +51,12 @@ class AntennaFactory(DatasetFactory):
         f"feed_id = {partition.feed_ids} and spw_id = {partition.spw_id}"
       )
 
-    antenna_names = filtered_ants["NAME"].to_numpy()
-    telescope_names = np.asarray([telescope_name] * len(antenna_names))
+    antenna_names = filtered_ants["NAME"].to_numpy().astype(str)
+    telescope_names = np.asarray([telescope_name] * len(antenna_names), dtype=str)
     position = pac.list_flatten(filtered_ants["POSITION"]).to_numpy().reshape(-1, 3)
     diameter = filtered_ants["DISH_DIAMETER"].to_numpy()
-    station = filtered_ants["STATION"].to_numpy()
-    mount = filtered_ants["MOUNT"].to_numpy()
+    station = filtered_ants["STATION"].to_numpy().astype(str)
+    mount = filtered_ants["MOUNT"].to_numpy().astype(str)
 
     filtered_feeds = feeds.take(np.where(mask)[0])
     nreceptors = filtered_feeds["NUM_RECEPTORS"].unique().to_numpy()
@@ -75,12 +75,13 @@ class AntennaFactory(DatasetFactory):
     pol_type = (
       pac.list_flatten(filtered_feeds["POLARIZATION_TYPE"])
       .to_numpy()
+      .astype(str)
       .reshape(-1, nreceptors.item())
     )
     receptor_labels = [f"pol_{i}" for i in range(nreceptors.item())]
 
-    metre_attrs = {"units": ["m"], "type": "quantity"}
-    rad_attrs = {"units": ["rad"], "type": "quantity"}
+    metre_attrs = {"units": "m", "type": "quantity"}
+    rad_attrs = {"units": "rad", "type": "quantity"}
 
     data_vars = {
       "ANTENNA_POSITION": Variable(
@@ -112,7 +113,7 @@ class AntennaFactory(DatasetFactory):
         "antenna_name": Variable("antenna_name", antenna_names),
         "mount": Variable("antenna_name", mount),
         "telescope_name": Variable("telescope_name", telescope_names),
-        "station": Variable("antenna_name", station),
+        "station_name": Variable("antenna_name", station),
         "cartesian_pos_label": Variable("cartesian_pos_label", ["x", "y", "z"]),
         "polarization_type": Variable(("antenna_name", "receptor_label"), pol_type),
         "receptor_label": Variable("receptor_label", receptor_labels),

--- a/xarray_ms/backend/msv2/factories/correlated.py
+++ b/xarray_ms/backend/msv2/factories/correlated.py
@@ -358,8 +358,9 @@ class CorrelatedFactory(DatasetFactory):
     return dict(
       sorted(
         {
-          "observer": obs["OBSERVER"][partition.obs_id].as_py(),
+          "observer": [obs["OBSERVER"][partition.obs_id].as_py()],
           "project": obs["PROJECT"][partition.obs_id].as_py(),
+          "intents": [partition.obs_mode],
         }.items()
       )
     )

--- a/xarray_ms/backend/msv2/factories/correlated.py
+++ b/xarray_ms/backend/msv2/factories/correlated.py
@@ -169,7 +169,7 @@ class CorrelatedFactory(DatasetFactory):
     assert (partition.nbl,) == ant1.shape
 
     antenna = self._subtable_factories["ANTENNA"].instance
-    ant_names = antenna["NAME"].to_numpy()
+    ant_names = antenna["NAME"].to_numpy().astype(str)
     ant1_names = ant_names[ant1]
     ant2_names = ant_names[ant2]
 
@@ -233,7 +233,7 @@ class CorrelatedFactory(DatasetFactory):
       data_vars.append(("WEIGHT", self._variable_from_column("WEIGHT_ROW", dim_sizes)))
 
     field = maybe_impute_field_table(field, partition.field_ids)
-    field_names = field.take(partition.field_ids)["NAME"].to_numpy()
+    field_names = field.take(partition.field_ids)["NAME"].to_numpy().astype(str)
 
     # Add coordinates indexing coordinates
     coordinates = [

--- a/xarray_ms/backend/msv2/factories/correlated.py
+++ b/xarray_ms/backend/msv2/factories/correlated.py
@@ -17,7 +17,10 @@ from xarray_ms.backend.msv2.array import (
 from xarray_ms.backend.msv2.encoders import (
   CasaCoder,
   QuantityCoder,
+  SpectralCoordCoder,
   TimeCoder,
+  UVWCoder,
+  VisibilityCoder,
 )
 from xarray_ms.backend.msv2.factories.core import DatasetFactory
 from xarray_ms.backend.msv2.imputation import (
@@ -49,13 +52,13 @@ MSV4_to_MSV2_COLUMN_SCHEMAS = {
   "INTEGRATION_TIME": MSv2ColumnSchema("INTERVAL", (), np.nan, QuantityCoder),
   "TIME_CENTROID": MSv2ColumnSchema("TIME_CENTROID", (), np.nan, TimeCoder),
   "EFFECTIVE_INTEGRATION_TIME": MSv2ColumnSchema("EXPOSURE", (), np.nan, QuantityCoder),
-  "UVW": MSv2ColumnSchema("UVW", ("uvw_label",), np.nan, None),
+  "UVW": MSv2ColumnSchema("UVW", ("uvw_label",), np.nan, UVWCoder),
   "FLAG_ROW": MSv2ColumnSchema(
     "FLAG_ROW", ("frequency", "polarization"), 1, None, low_res_dims=()
   ),
   "FLAG": MSv2ColumnSchema("FLAG", ("frequency", "polarization"), 1, None),
   "VISIBILITY": MSv2ColumnSchema(
-    "DATA", ("frequency", "polarization"), np.nan + np.nan * 1j, None
+    "DATA", ("frequency", "polarization"), np.nan + np.nan * 1j, VisibilityCoder
   ),
   "WEIGHT_ROW": MSv2ColumnSchema(
     "WEIGHT",
@@ -186,7 +189,8 @@ class CorrelatedFactory(DatasetFactory):
     spw_freq_group_name = spw["FREQ_GROUP_NAME"][spw_id].as_py()
     spw_ref_freq = spw["REF_FREQUENCY"][spw_id].as_py()
     spw_meas_freq_ref = spw["MEAS_FREQ_REF"][spw_id].as_py()
-    spw_frame = FrequencyMeasures(spw_meas_freq_ref).name.upper()
+    spw_frame_name = FrequencyMeasures(spw_meas_freq_ref).name.upper()
+    spw_frame = SpectralCoordCoder.casa_to_astropy(spw_frame_name)
 
     corr_type = Polarisations.from_values(pol["CORR_TYPE"][pol_id].as_py()).to_str()
 

--- a/xarray_ms/backend/msv2/factories/correlated.py
+++ b/xarray_ms/backend/msv2/factories/correlated.py
@@ -1,5 +1,6 @@
 import dataclasses
 import warnings
+from datetime import datetime, timezone
 from typing import Any, Dict, Mapping, Tuple, Type
 
 import numpy as np
@@ -361,6 +362,10 @@ class CorrelatedFactory(DatasetFactory):
           "observer": [obs["OBSERVER"][partition.obs_id].as_py()],
           "project": obs["PROJECT"][partition.obs_id].as_py(),
           "intents": [partition.obs_mode],
+          # TODO: Correct this to the value of the actual column
+          "release_date": datetime(
+            1978, 10, 9, 8, 0, 0, tzinfo=timezone.utc
+          ).isoformat(),
         }.items()
       )
     )

--- a/xarray_ms/backend/msv2/factories/field_and_source.py
+++ b/xarray_ms/backend/msv2/factories/field_and_source.py
@@ -57,7 +57,7 @@ class FieldAndSourceFactory(DatasetFactory):
       coords={
         "field_name": Variable("field_name", field_names),
         "sky_dir_label": Variable("sky_dir_label", ["ra", "dec"]),
-        "source_name": Variable("Source_name", source_names),
+        "source_name": Variable("source_name", source_names),
       },
       attrs={"type": "field_and_source"},
     )

--- a/xarray_ms/backend/msv2/factories/field_and_source.py
+++ b/xarray_ms/backend/msv2/factories/field_and_source.py
@@ -35,13 +35,14 @@ class FieldAndSourceFactory(DatasetFactory):
     field_columns = set(field.column_names)
     data_vars = {}
     if "PHASE_DIR" in field_columns:
+      column_desc = json.loads(field.schema.field("PHASE_DIR").metadata[b"__arcae_metadata__"])["__casa_descriptor__"]
       phase_centre = pac.list_flatten(field["PHASE_DIR"], recursive=True)
       phase_centre = phase_centre.to_numpy().reshape(len(field), 2)
       data_vars["FIELD_PHASE_CENTER_DIRECTION"] = Variable(
         ("field_name", "sky_dir_label"), phase_centre
       )
 
-    field_names = field["NAME"].to_numpy()
+    field_names = field["NAME"].to_numpy().astype(str)
     # Filter out negative source ids
     pa_source_ids = pa.array(source_ids)
     pa_source_ids = pac.replace_with_mask(
@@ -50,7 +51,7 @@ class FieldAndSourceFactory(DatasetFactory):
       pa.array([None] * len(source_ids), pa_source_ids.type),
     )
     pa_source_names = pac.take(source["NAME"], pa_source_ids)
-    source_names = pac.fill_null(pa_source_names, "UNKNOWN").to_numpy()
+    source_names = pac.fill_null(pa_source_names, "UNKNOWN").to_numpy().astype(str)
 
     return Dataset(
       data_vars=data_vars,

--- a/xarray_ms/backend/msv2/factories/field_and_source.py
+++ b/xarray_ms/backend/msv2/factories/field_and_source.py
@@ -35,7 +35,6 @@ class FieldAndSourceFactory(DatasetFactory):
     field_columns = set(field.column_names)
     data_vars = {}
     if "PHASE_DIR" in field_columns:
-      column_desc = json.loads(field.schema.field("PHASE_DIR").metadata[b"__arcae_metadata__"])["__casa_descriptor__"]
       phase_centre = pac.list_flatten(field["PHASE_DIR"], recursive=True)
       phase_centre = phase_centre.to_numpy().reshape(len(field), 2)
       data_vars["FIELD_PHASE_CENTER_DIRECTION"] = Variable(

--- a/xarray_ms/backend/msv2/factories/field_and_source.py
+++ b/xarray_ms/backend/msv2/factories/field_and_source.py
@@ -1,11 +1,14 @@
 import numpy as np
 from xarray import Dataset, Variable
 
+from xarray_ms.backend.msv2.encoders import DirectionCoder
 from xarray_ms.backend.msv2.factories.core import DatasetFactory
 from xarray_ms.backend.msv2.imputation import (
   maybe_impute_field_table,
   maybe_impute_source_table,
 )
+from xarray_ms.backend.msv2.table_utils import table_desc
+from xarray_ms.casa_types import ColumnDesc
 
 
 class FieldAndSourceFactory(DatasetFactory):
@@ -24,6 +27,8 @@ class FieldAndSourceFactory(DatasetFactory):
     source_ids = field["SOURCE_ID"].to_numpy()
     source = maybe_impute_source_table(source, source_ids)
 
+    field_table_desc = table_desc(field)
+
     num_poly = np.unique(field["NUM_POLY"].to_numpy())
     if not num_poly == [0]:
       raise NotImplementedError(
@@ -37,9 +42,12 @@ class FieldAndSourceFactory(DatasetFactory):
     if "PHASE_DIR" in field_columns:
       phase_centre = pac.list_flatten(field["PHASE_DIR"], recursive=True)
       phase_centre = phase_centre.to_numpy().reshape(len(field), 2)
-      data_vars["FIELD_PHASE_CENTER_DIRECTION"] = Variable(
-        ("field_name", "sky_dir_label"), phase_centre
+      field_phase_centre_dir = Variable(("field_name", "sky_dir_label"), phase_centre)
+      phase_dir_coldesc = ColumnDesc.from_descriptor("PHASE_DIR", field_table_desc)
+      coder = DirectionCoder(phase_dir_coldesc).with_var_ref_cols(
+        lambda c: field[c].to_numpy()
       )
+      data_vars["FIELD_PHASE_CENTER_DIRECTION"] = coder.decode(field_phase_centre_dir)
 
     field_names = field["NAME"].to_numpy().astype(str)
     # Filter out negative source ids

--- a/xarray_ms/backend/msv2/factories/field_and_source.py
+++ b/xarray_ms/backend/msv2/factories/field_and_source.py
@@ -57,7 +57,7 @@ class FieldAndSourceFactory(DatasetFactory):
       coords={
         "field_name": Variable("field_name", field_names),
         "sky_dir_label": Variable("sky_dir_label", ["ra", "dec"]),
-        "source_name": Variable("source_name", source_names),
+        "source_name": Variable("field_name", source_names),
       },
       attrs={"type": "field_and_source"},
     )

--- a/xarray_ms/backend/msv2/imputation.py
+++ b/xarray_ms/backend/msv2/imputation.py
@@ -144,7 +144,7 @@ def maybe_impute_processor_table(
   processor: pa.Table, processor_id: npt.NDArray[np.int32]
 ) -> pa.Table:
   """Generates a PROCESSOR table if there are no row ids
-  associated with the given PROESSOR_ID values"""
+  associated with the given PROCESSOR_ID values"""
   import pyarrow as pa
 
   result = _maybe_return_table_or_max_id(

--- a/xarray_ms/backend/msv2/table_utils.py
+++ b/xarray_ms/backend/msv2/table_utils.py
@@ -1,0 +1,19 @@
+import json
+from typing import Any, Dict
+
+import pyarrow as pa
+
+
+def table_desc(table: pa.Table) -> Dict[str, Any]:
+  """Extract the CASA table descriptor stored in an Arrow table constructed by arcae"""
+  try:
+    arcae_metadata = table.schema.metadata[b"__arcae_metadata__"]
+  except KeyError:
+    raise KeyError("__arcae_metadata__ was not present in the table metadata")
+
+  try:
+    return json.loads(arcae_metadata)["__casa_descriptor__"]
+  except KeyError:
+    raise KeyError(
+      f"arcae metadata {arcae_metadata} does not contain a __casa_descriptor__"
+    )

--- a/xarray_ms/casa_types.py
+++ b/xarray_ms/casa_types.py
@@ -132,6 +132,55 @@ class FrequencyMeasures(IntEnum):
   CMB = 8
 
 
+class DirectionMeasures(IntEnum):
+  """Enumeration of CASA Direction Measure Types
+  defined at casacore/measures/Measures/MDirection.h
+  """
+
+  J2000 = 0
+  JMEAN = 1
+  JTRUE = 2
+  APP = 3
+  B1950 = 4
+  B1950_VLA = 5
+  BMEAN = 6
+  BTRUE = 7
+  GALACTIC = 8
+  HADEC = 9
+  AZEL = 10
+  AZELSW = 11
+  AZELGEO = 12
+  AZELSWGEO = 13
+  JNAT = 14
+  ECLIPTIC = 15
+  MECLIPTIC = 16
+  TECLIPTIC = 17
+  SUPERGAL = 18
+  ITRF = 19
+  TOPO = 20
+  ICRS = 21
+  MERCURY = 22
+  VENUS = 23
+  MARS = 24
+  JUPITER = 25
+  SATURN = 26
+  URANUS = 27
+  NEPTUNE = 28
+  PLUTO = 29
+  SUN = 30
+  MOON = 31
+  COMET = 32
+
+class PositionMeasures(IntEnum):
+  """Enumeration of CASA Position Measure Types
+  defined at casacore/measures/Measures/MPosition.h
+  """
+
+  ITRF = 0
+  WGS84 = 1
+
+
+
 class DataType(IntEnum):
   """
   Enumeration of CASA Data Types, defined at

--- a/xarray_ms/casa_types.py
+++ b/xarray_ms/casa_types.py
@@ -171,6 +171,7 @@ class DirectionMeasures(IntEnum):
   MOON = 31
   COMET = 32
 
+
 class PositionMeasures(IntEnum):
   """Enumeration of CASA Position Measure Types
   defined at casacore/measures/Measures/MPosition.h
@@ -178,7 +179,6 @@ class PositionMeasures(IntEnum):
 
   ITRF = 0
   WGS84 = 1
-
 
 
 class DataType(IntEnum):

--- a/xarray_ms/errors.py
+++ b/xarray_ms/errors.py
@@ -26,6 +26,11 @@ class ImputedMetadataWarning(MissingMetadataWarning):
   if the original metadata is missing"""
 
 
+class FrameConversionWarning(UserWarning):
+  """Warning raised if there's no defined conversion from a CASA
+  to astropy reference frame"""
+
+
 class InvalidMeasurementSet(ValueError):
   """Raised when the Measurement Set foreign key indexing is invalid"""
 

--- a/xarray_ms/errors.py
+++ b/xarray_ms/errors.py
@@ -44,3 +44,7 @@ class MissingMeasuresInfo(ValueError):
 
 class MissingQuantumUnits(ValueError):
   """Raised when QuantumUnits information is missing from the column"""
+
+
+class MultipleQuantumUnits(ValueError):
+  """Raised when there are multiple QuantumUnit value types in the column"""

--- a/xarray_ms/testing/simulator.py
+++ b/xarray_ms/testing/simulator.py
@@ -225,7 +225,10 @@ class MSStructureSimulator:
 
     # Generate descriptors, create simulated data from the descriptors
     # and write simulated data to the main Measurement Set
-    with Table.ms_from_descriptor(output_ms, "MAIN", self.table_desc) as T:
+    table_desc = {**ms_descriptor("MAIN"), **self.table_desc}
+    table_desc["UVW"]["keywords"]["MEASINFO"]["Ref"] = "J2000"
+
+    with Table.ms_from_descriptor(output_ms, "MAIN", table_desc) as T:
       startrow = 0
 
       for chunk_desc in self.generate_descriptors():

--- a/xarray_ms/testing/utils.py
+++ b/xarray_ms/testing/utils.py
@@ -1,6 +1,10 @@
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from xarray import Dataset, DataTree
+
+from xarray_ms.msv4_types import CORRELATED_DATASET_TYPES
+
 
 def id_string(arg: Any) -> str:
   """Converts an argument into a string that can be used as a pytest identifier."""
@@ -13,3 +17,22 @@ def id_string(arg: Any) -> str:
     return f"[{bits}]"
   else:
     return str(arg)
+
+
+def prune_datetime_structures(xarray_structure: DataTree | DataTree):
+  """Prune date values out of Dataset or DataTrees for equality testing"""
+
+  def prune_vis_dataset(ds):
+    ds.attrs.pop("creation_date", None)
+
+    for dg in ds.attrs.get("data_groups", {}).values():
+      dg.pop("date", None)
+
+  if isinstance(xarray_structure, Dataset):
+    prune_vis_dataset(xarray_structure)
+  elif isinstance(xarray_structure, DataTree):
+    for node in xarray_structure.subtree:
+      if node.attrs.get("type") in CORRELATED_DATASET_TYPES:
+        prune_vis_dataset(node.ds)
+
+  return xarray_structure


### PR DESCRIPTION
This PR contains many attributes fixes after running the MSv4 schema checker on DataTree's produced by xarray-ms.

Amongst other things, the measures handling is improved to handle basic VarRefCols cases in MEASINFO, which seem to be the only ones present in the MSv4 Test Corpus:

- Partially address #22 

<!-- -->

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--125.org.readthedocs.build/en/125/

<!-- readthedocs-preview xarray-ms end -->