### PR TITLE
Documentation updates

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -4,19 +4,13 @@ API
 Opening Measurement Sets
 ------------------------
 
-The standard :func:`xarray.backends.api.open_dataset` and
-:func:`xarray.backends.api.open_datatree` methods should
-be used to open either a :class:`~xarray.Dataset` or a
-:class:`~xarray.DataTree`.
+The standard :func:`xarray.open_datatree` method should
+be used to open a :class:`~xarray.DataTree` interface
+to the underlying Measurement Set data.
 
 .. code-block:: python
 
-    >>> dataset = xarray.open_dataset(
-                    "/data/data.ms",
-                    partition_schema=["DATA_DESC_ID", "FIELD_ID"])
-    >>> datatree = xarray.backends.api.open_datatree(
-                    "/data/data.ms",
-                    partition_schema=["DATA_DESC_ID", "FIELD_ID"])
+    >>> datatree = xarray.open_datatree("/data/data.ms", partition_schema=["FIELD_ID"])
 
 These methods defer to the relevant methods on the
 `Entrypoint Class <entrypoint-class_>`_.
@@ -32,23 +26,6 @@ Entrypoint Class
 Entrypoint class for the MSv2 backend.
 
 .. autoclass:: xarray_ms.backend.msv2.entrypoint.MSv2EntryPoint
-    :members: open_dataset, open_datatree
+    :members: open_datatree, open_dataset
 
 .. _partitioning-schema:
-
-Partioning Schema
------------------
-
-The default partitioning schema contains the following columns:
-
-.. autodata:: xarray_ms.backend.msv2.structure.DEFAULT_PARTITION_COLUMNS
-
-Partitioning always uses these columns, but additional columns can be
-selected if finer grained partitioning is required:
-
-.. autodata:: xarray_ms.backend.msv2.structure.VALID_PARTITION_COLUMNS
-
-Note that ``OBS_MODE`` and ``SUB_SCAN_NUMBER`` are columns in the ``STATE``
-subtable, while ``SOURCE_ID`` is a column of the ``FIELD`` subtable.
-Partitioning on these columns is achieved by joining on the ``STATE_ID``
-and ``FIELD_ID`` columns, respectively.

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Documentation updates (:pr:`134`)
 * Temporarily restrict xarray to \< 2025.9.1 (:pr:`136`) until
   `xarray#10808 <https://github.com/pydata/xarray/issues/10808_>`_
   is resolved.

--- a/doc/source/partitioning.rst
+++ b/doc/source/partitioning.rst
@@ -38,10 +38,10 @@ Additionally, the ``DATA_DESC_ID`` column establishes a relation to the
 ``SPECTRAL_WINDOW::CHAN_FREQ`` and ``SPECTRAL_WINDOW::CHAN_WIDTH`` columns
 representing the frequency centroid and bandwidth of the sample, respectively.
 
-The challenge that MSv2 poses to radio astronomy software in the worst case,
+The challenge that MSv2 poses to radio astronomy software in the worst case
 is that it can represent overlapped or disjoint measurements in time and frequency
 for one or more baselines.
-However, most observational data is quite well-behaved:
+However, most observational data is well-behaved:
 Measurements are commonly ordered by ``TIME, ANTENNA1, ANTENNA2``
 and ``CHAN_FREQ`` commonly increases monotically with
 equidistant values (i.e. ``CHAN_WIDTH`` values are uniform) but this cannot
@@ -56,13 +56,27 @@ Choosing a partitioning strategy
 By default, MSv2 measurements are partitioned by ``DATA_DESC_ID``,
 ``OBSERVATION_ID``, ``PROCESSOR_ID`` and the
 ``STATE::OBS_MODE`` (via ``STATE_ID``) columns.
+
+.. autodata:: xarray_ms.backend.msv2.structure.DEFAULT_PARTITION_COLUMNS
+
 For example, it follows from the previous section that,
 in order to achieve regularity in frequency, *partition*
 MSv2 measurements by the ``DATA_DESC_ID`` column.
 
+Partitioning always uses these columns, but additional columns can be
+selected if finer grained partitioning is required:
+
+.. autodata:: xarray_ms.backend.msv2.structure.VALID_PARTITION_COLUMNS
+
+Note that ``OBS_MODE`` and ``SUB_SCAN_NUMBER`` are columns in the ``STATE``
+subtable, while ``SOURCE_ID`` is a column of the ``FIELD`` subtable.
+Partitioning on these columns is achieved by joining on the ``STATE_ID``
+and ``FIELD_ID`` columns, respectively.
+
+
 Within these partitions, measurements are sorted by
 ``TIME``, ``ANTENNA1`` and ``ANTENNA2``
-then forming a grid.
+to form a grid.
 
 .. _time-partitioning:
 
@@ -132,14 +146,14 @@ related to each of the three dimensions.
 This warning is raised when it is impossible
 to identify a unique ``INTERVAL`` value for a partition.
 This is required to assign a single ``integration_time``
-to the ``time`` coordinate.
+attribute to the ``time`` coordinate.
 
 The above check is relaxed slightly by excluding the last time
 in the partition (to handle averaged data) and by allowing
 a degree of jitter in the ``INTERVAL`` column.
 
 Generally, this happens if the requested partitioning schema
-does not satisfy the criteria in :ref:`time-partitioning`.
+does not satisfy the criteria described in :ref:`time-partitioning`.
 The solution is to experiment with other partitioning columns.
 
 Should the user wish to continue with this case,

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -16,13 +16,13 @@ or group MSv2 rows by the same shape and configuration.
 In xarray-ms, this is accomplished by specifying a ``partition_schema``
 when opening a Measurement Set.
 Different columns may be used to define the partition.
-See :ref:`partitioning-schema` for more information.
+See :ref:`partitioning-guide` for more information.
 
 Opening a Measurement Set
 -------------------------
 
 As xarray-ms implements an `xarray backend <xarray_backend_>`_,
-it is possible to use the :func:`xarray.backends.api.open_datatree` function
+it is possible to use the :func:`xarray.open_datatree` function
 to open multiple partitions of a Measurement Set.
 
 .. ipython:: python
@@ -50,7 +50,7 @@ to open multiple partitions of a Measurement Set.
 Selecting a subset of the data
 ++++++++++++++++++++++++++++++
 
-By default, :func:`~xarray.backends.api.open_datatree` will return a datatree
+By default, :func:`~xarray.open_datatree` will return a datatree
 with a lazy view over the data.
 xarray has extensive functionality for
 `indexing and selecting data <xarray_indexing_and_selecting_>`_.


### PR DESCRIPTION
Largely consistency updates

- Place all partitioning information in the Partioning Guide section
- Use `xarray.open_datatree`  instead of `xarray.backend.api.open_datatree`

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->


- [ ] Test Cases covering your PR.
- [x] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--134.org.readthedocs.build/en/134/

<!-- readthedocs-preview xarray-ms end -->