### PR TITLE
Modify MSv2EntryPoint with support_groups=True

### DIFF
--- a/tests/test_zarr_roundtrip.py
+++ b/tests/test_zarr_roundtrip.py
@@ -1,18 +1,21 @@
+import xarray
 import xarray.testing as xt
-from xarray.backends.api import open_dataset, open_datatree
 
 
 def test_dataset_roundtrip(simmed_ms, tmp_path):
-  ds = open_dataset(simmed_ms)
+  ds = xarray.open_dataset(simmed_ms)
   zarr_path = tmp_path / "test_dataset.zarr"
   ds.to_zarr(zarr_path, compute=True, consolidated=True)
-  ds2 = open_dataset(zarr_path)
+  ds2 = xarray.open_dataset(zarr_path)
   xt.assert_identical(ds, ds2)
 
 
 def test_datatree_roundtrip(simmed_ms, tmp_path):
-  dt = open_datatree(simmed_ms)
+  dt = xarray.open_datatree(simmed_ms)
   zarr_path = tmp_path / "test_datatree.zarr"
   dt.to_zarr(zarr_path, compute=True, consolidated=True)
-  dt2 = open_datatree(zarr_path)
+  # TODO Remove forcing of engine once
+  # https://github.com/pydata/xarray/issues/10808
+  # is resolved
+  dt2 = xarray.open_datatree(zarr_path, engine="zarr")
   xt.assert_identical(dt, dt2)

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -225,6 +225,7 @@ class MSv2EntryPoint(BackendEntrypoint):
   ]
   description = "Opens v2 CASA Measurement Sets in Xarray"
   url = "https://xarray-ms.readthedocs.io/"
+  supports_groups = True
 
   def guess_can_open(
     self, filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

xarray 2025.09.1 introduced a `support_groups` class variable to BackendEntryPoint classes.
When `support_groups=False`, `xarray.open_datatree` fails to consider the engine.
Related xarray issue.

- https://github.com/pydata/xarray/issues/10808


- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--135.org.readthedocs.build/en/135/

<!-- readthedocs-preview xarray-ms end -->