### PR TITLE
Restrict xarray to < 2025.9.1 and arcae to < 0.4.0

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Temporarily restrict xarray to \< 2025.9.1 (:pr:`136`) until
+   `xarray#10808 <https://github.com/pydata/xarray/issues/10808>`_
+  is resolved.
+* Restrict arcae to \< 0.4.0 to prevent
+  API-breaking write support changes (:pr:`136`)
 * Provide a physically realistic SPECTRAL_WINDOW::REF_FREQUENCY in simulated data (:pr:`133`)
 
 0.3.6 (22-09-2025)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{name = "Simon Perkins", email = "simon.perkins@gmail.com"}]
 readme = "README.rst"
 requires-python = ">=3.10"
 dependencies = [
-    "xarray>=2025.0",
+    "xarray>=2025.0, < 2025.9.1",
     "cacheout>=0.16.0",
     "arcae>=0.3.2",
     "typing-extensions>=4.12.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 dependencies = [
     "xarray>=2025.0, < 2025.9.1",
     "cacheout>=0.16.0",
-    "arcae>=0.3.2",
+    "arcae>=0.3.2, < 0.4.0",
     "typing-extensions>=4.12.2",
 ]
 

--- a/tests/test_zarr_roundtrip.py
+++ b/tests/test_zarr_roundtrip.py
@@ -1,18 +1,21 @@
+import xarray
 import xarray.testing as xt
-from xarray.backends.api import open_dataset, open_datatree
 
 
 def test_dataset_roundtrip(simmed_ms, tmp_path):
-  ds = open_dataset(simmed_ms)
+  ds = xarray.open_dataset(simmed_ms)
   zarr_path = tmp_path / "test_dataset.zarr"
   ds.to_zarr(zarr_path, compute=True, consolidated=True)
-  ds2 = open_dataset(zarr_path)
+  ds2 = xarray.open_dataset(zarr_path)
   xt.assert_identical(ds, ds2)
 
 
 def test_datatree_roundtrip(simmed_ms, tmp_path):
-  dt = open_datatree(simmed_ms)
+  dt = xarray.open_datatree(simmed_ms)
   zarr_path = tmp_path / "test_datatree.zarr"
   dt.to_zarr(zarr_path, compute=True, consolidated=True)
-  dt2 = open_datatree(zarr_path)
+  # TODO Remove forcing of engine once
+  # https://github.com/pydata/xarray/issues/10808
+  # is resolved
+  dt2 = xarray.open_datatree(zarr_path, engine="zarr")
   xt.assert_identical(dt, dt2)

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -225,6 +225,7 @@ class MSv2EntryPoint(BackendEntrypoint):
   ]
   description = "Opens v2 CASA Measurement Sets in Xarray"
   url = "https://xarray-ms.readthedocs.io/"
+  supports_groups = True
 
   def guess_can_open(
     self, filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Temporarily, restrict xarray to < 2025.9.1 due to 

- https://github.com/pydata/xarray/issues/10808
- #135 

Restrict arcae to < 0.4.0 as the 0.4.x branch contains experimental write support

- pip restricts the alpha qualifiers on the current releases in the 0.4.0 branch
- but uv does not
- This future proofs the xarray-ms main branch against arcae 0.4.x releases

We would appreciate it if you could add:

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--136.org.readthedocs.build/en/136/

<!-- readthedocs-preview xarray-ms end -->