### PR TITLE
Fix dask unpickling error when computing WEIGHT on an MS without WEIGHT_SPECTRUM column

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+Unreleased
+----------
+* Fix dask unpickling error when broadcasting the MSv2 WEIGHT column to its full MSv4 shape
+
 0.5.0 (02-03-2026)
 ------------------
 * Fix ``VisibilityCoder`` typo (:pr:`145`)

--- a/xarray_ms/backend/msv2/array.py
+++ b/xarray_ms/backend/msv2/array.py
@@ -176,6 +176,10 @@ class BroadcastMSv2Array(MSv2Array):
   def dtype(self):
     return self._low_res_array.dtype
 
+  @dtype.setter
+  def dtype(self, value: npt.DTypeLike) -> None:
+    self._low_res_array.dtype = value
+
   @property
   def transform(self) -> TransformerT | None:
     return self._low_res_array.transform


### PR DESCRIPTION
Hello there,

I'm prototyping a pipeline using `xarray-ms`, and ran into this error when running it on an MS which only has the WEIGHT column -- which is the case for all our SKA Low simulations.

```
Traceback (most recent call last):
  File "/home/vince/repo/ska-sdp-skippy/.venv/lib/python3.11/site-packages/distributed/scheduler.py", line 4873, in update_graph
    expr = deserialize(expr_ser.header, expr_ser.frames)
^^^^^^^^^^^
  File "/home/vince/repo/ska-sdp-skippy/.venv/lib/python3.11/site-packages/distributed/protocol/serialize.py", line 452, in deserialize
    return loads(header, frames)
      ^^^^^^^^^^^^^^^^^
  File "/home/vince/repo/ska-sdp-skippy/.venv/lib/python3.11/site-packages/distributed/protocol/serialize.py", line 111, in pickle_loads
    return pickle.loads(pik, buffers=buffers)
      ^^^^^^^^^^^^^^^^^
  File "/home/vince/repo/ska-sdp-skippy/.venv/lib/python3.11/site-packages/distributed/protocol/pickle.py", line 93, in loads
    return pickle.loads(x, buffers=buffers)
^^^^^^^^^^^^^^^
AttributeError: property 'dtype' of 'BroadcastMSv2Array' object has no setter
```

A minimum reproducible example is worth many words:
```python
import xarray_ms
import xarray as xr

from dask.distributed import Client

def first_sample_weights():
    # Simulated dataset with only WEIGHT column
    # Chunking is necessary to trigger the unpickling error
    xdt = xr.open_datatree("oskar.ms", chunks={"time": 64, "frequency": 64})
    msv4 = next(iter(xdt.children.values()))
    return msv4.isel(time=slice(0, 1)).WEIGHT

def works():
    print(first_sample_weights().compute())

def fails():
    with Client():
        print(first_sample_weights().compute())

if __name__ == "__main__":
    works()
    fails()
```

The problem comes from the fact that the parent class `MSv2Array` has a member called `dtype`, which gets shadowed by a property with the same name in the derived class `BroadcastMSv2Array`. It just needs to be set-able.

<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--146.org.readthedocs.build/en/146/

<!-- readthedocs-preview xarray-ms end -->