### PR TITLE
Fix MSv2BroadcastArray pickling error

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 =========
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Correct ``BroadcastMSv2Array`` initialisation of ``MSv2Array`` base class
+  which resulted in unpickleable ``BroadcastMSv2Array`` instances. (:pr:`147`)
+
 0.5.0 (02-03-2026)
 ------------------
 * Fix ``VisibilityCoder`` typo (:pr:`145`)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,3 +1,4 @@
+import pickle
 from contextlib import nullcontext
 from functools import reduce
 from operator import mul
@@ -294,6 +295,27 @@ def test_low_resolution_read(simmed_ms):
     assert_array_equal(
       np.broadcast_to(values, (ntime, nbl, nfreq, npol)), node.WEIGHT.values
     )
+
+
+@pytest.mark.parametrize(
+  "simmed_ms",
+  [
+    {
+      "name": "backend.ms",
+      "data_description": [(8, ["XX", "XY", "YX", "YY"]), (4, ["RR", "LL"])],
+      "table_desc": {"__remove_columns__": ["WEIGHT_SPECTRUM"]},
+      "transform_data": _remove_weight_spectrum_add_weight,
+    }
+  ],
+  indirect=True,
+)
+def test_datatree_pickleable(simmed_ms):
+  """Test that the resulting datatree is pickleable.
+
+  WEIGHT_SPECTRUM is replaced with WEIGHT to test
+  https://github.com/ratt-ru/xarray-ms/pull/146"""
+  dt = xarray.open_datatree(simmed_ms, auto_corrs=True)
+  xarray.testing.assert_identical(dt, pickle.loads(pickle.dumps(dt)))
 
 
 @pytest.mark.parametrize(

--- a/xarray_ms/backend/msv2/array.py
+++ b/xarray_ms/backend/msv2/array.py
@@ -34,19 +34,18 @@ def slice_length(s: npt.NDArray | slice, max_len) -> int:
 
 
 class MSv2Array(BackendArray):
-  """Base MSv2Array backend array class,
-  containing required shape and data type"""
+  """Base MSv2Array backend array class"""
 
   __slots__ = ("shape", "dtype")
 
   shape: Tuple[int, ...]
   dtype: npt.DTypeLike
 
-  def __init__(self, shape: Tuple[int, ...], dtype: npt.DTypeLike):
+  def __init__(self, shape: Tuple[int, ...], dtype: npt.NDTypeLike):
     self.shape = shape
     self.dtype = dtype
 
-  def __getitem__(self, key) -> npt.NDArray:
+  def __getitem__(self, key):
     raise NotImplementedError
 
   @property
@@ -73,6 +72,8 @@ class MainMSv2Array(MSv2Array):
     "_transform",
   )
 
+  shape: Tuple[int, ...]
+  dtype: npt.DTypeLike
   _table_factory: Multiton
   _structure_factory: MSv2StructureFactory
   _partition: PartitionKeyT
@@ -160,7 +161,6 @@ class BroadcastMSv2Array(MSv2Array):
 
   _low_res_array: MSv2Array
   _low_res_index: Tuple[slice | npt.NDArray | None, ...]
-  shape: Tuple[int, ...]
 
   def __init__(
     self,
@@ -168,13 +168,9 @@ class BroadcastMSv2Array(MSv2Array):
     low_res_index: Tuple[slice | npt.NDArray | None, ...],
     high_res_shape: Tuple[int, ...],
   ):
+    super().__init__(high_res_shape, low_res_array.dtype)
     self._low_res_array = low_res_array
     self._low_res_index = low_res_index
-    self.shape = high_res_shape
-
-  @property
-  def dtype(self):
-    return self._low_res_array.dtype
 
   @property
   def transform(self) -> TransformerT | None:

--- a/xarray_ms/backend/msv2/array.py
+++ b/xarray_ms/backend/msv2/array.py
@@ -34,7 +34,8 @@ def slice_length(s: npt.NDArray | slice, max_len) -> int:
 
 
 class MSv2Array(BackendArray):
-  """Base MSv2Array backend array class"""
+  """Base MSv2Array backend array class,
+  containing required shape and data type"""
 
   __slots__ = ("shape", "dtype")
 

--- a/xarray_ms/backend/msv2/array.py
+++ b/xarray_ms/backend/msv2/array.py
@@ -41,7 +41,7 @@ class MSv2Array(BackendArray):
   shape: Tuple[int, ...]
   dtype: npt.DTypeLike
 
-  def __init__(self, shape: Tuple[int, ...], dtype: npt.NDTypeLike):
+  def __init__(self, shape: Tuple[int, ...], dtype: npt.DTypeLike):
     self.shape = shape
     self.dtype = dtype
 

--- a/xarray_ms/backend/msv2/array.py
+++ b/xarray_ms/backend/msv2/array.py
@@ -45,7 +45,7 @@ class MSv2Array(BackendArray):
     self.shape = shape
     self.dtype = dtype
 
-  def __getitem__(self, key):
+  def __getitem__(self, key) -> npt.NDArray:
     raise NotImplementedError
 
   @property
@@ -72,8 +72,6 @@ class MainMSv2Array(MSv2Array):
     "_transform",
   )
 
-  shape: Tuple[int, ...]
-  dtype: npt.DTypeLike
   _table_factory: Multiton
   _structure_factory: MSv2StructureFactory
   _partition: PartitionKeyT


### PR DESCRIPTION
The MSv2Array -> MainMSv2Array -> BroadcastMSv2Array inheritance hierarchy resulted in an error when pickling a BroadcastMSv2Array. The related PR

- https://github.com/ratt-ru/xarray-ms/pull/146 

fixes the proximal causes but the root cause is the shadowing of `MSv2Array.dtype` by the `BroadcastMSv2Array.dtype` property.  This PR corrects the use of the inheritance hierarchy and adds a test case testing that the returned datatree is pickleable.

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--147.org.readthedocs.build/en/147/

<!-- readthedocs-preview xarray-ms end -->