### PR TITLE
Depend on xradio to test xarray-ms MSv4 Datatree compliance

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Depend on xradio to test xarray-ms MSv4 Datatree compliance (:pr:`148`)
+
 0.5.0 (02-03-2026)
 ------------------
 * Fix ``VisibilityCoder`` typo (:pr:`145`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ testing = [
     "distributed>=2024.5.0",
     "zarr>=2.18.3, <3.0.0",
     "platformdirs>=4.3.8",
+    "xradio>=1.1.2; python_version >= '3.11' and python_version < '3.14'",
 ]
 dev = [
     "pre-commit>=3.8.0",

--- a/tests/msv4_test_corpus/test_msv_corpus.py
+++ b/tests/msv4_test_corpus/test_msv_corpus.py
@@ -1,4 +1,5 @@
 import os.path
+import warnings
 
 import pytest
 import xarray
@@ -7,9 +8,15 @@ import xarray_ms  # noqa
 
 # If present, use xradio to perform schema checking
 try:
-  import xradio  # noqa
-  import xradio.measurement_set  # noqa. Required to register types for check_datatree
-  from xradio.schema.check import check_datatree
+  with warnings.catch_warnings():
+    warnings.filterwarnings(
+      "ignore",
+      category=UserWarning,
+      message="Could not import the function to convert from MSv2 to MSv4.",
+    )
+    import xradio  # noqa
+    import xradio.measurement_set  # noqa. Required to register types for check_datatree
+    from xradio.schema.check import check_datatree
 except ImportError:
   xradio = None
 
@@ -17,6 +24,9 @@ pmx = pytest.mark.xfail
 
 
 @pytest.mark.msv4_test_corpus
+@pytest.mark.filterwarnings(
+  "ignore:Could not import the function to convert from MSv2 to MSv4"
+)
 @pytest.mark.filterwarnings("ignore::xarray_ms.errors.FrameConversionWarning")
 @pytest.mark.filterwarnings("ignore::xarray_ms.errors.ImputedMetadataWarning")
 @pytest.mark.filterwarnings("ignore::xarray_ms.errors.IrregularTimeGridWarning")


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--148.org.readthedocs.build/en/148/

<!-- readthedocs-preview xarray-ms end -->