### PR TITLE
Depend on arcae >= 0.5.1, < 0.6.0

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Depend on arcae ``>= 0.5.1, < 0.6.0`` (:pr:`149`)
+
 0.5.1 (06-03-2026)
 ------------------
 * Correct ``BroadcastMSv2Array`` initialisation of ``MSv2Array`` base class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 dependencies = [
     "xarray>=2025.0",
     "cacheout>=0.16.0",
-    "arcae>=0.3.2, < 0.4.0",
+    "arcae>=0.5.1, < 0.6.0",
     "typing-extensions>=4.12.2",
 ]
 


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

arcae 0.5.x versions contain write support only.

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--149.org.readthedocs.build/en/149/

<!-- readthedocs-preview xarray-ms end -->