### PR TITLE
Deprecate python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "macos-13", "macos-14", "macos-15"]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         is_main_or_release:
           - ${{ contains(github.ref, 'main') || startsWith(github.ref, 'refs/tags')}}
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,41 +31,6 @@ jobs:
       matrix:
         os: ["ubuntu-22.04", "macos-13", "macos-14", "macos-15"]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
-        is_main_or_release:
-          - ${{ contains(github.ref, 'main') || startsWith(github.ref, 'refs/tags')}}
-        exclude:
-          # Don't test on macos-{13,14} in PR's
-          - is_main_or_release: false
-            os: "macos-13"
-          - is_main_or_release: false
-            os: "macos-14"
-          # Don't test on 3.10 - 3.12 in PR's
-          - is_main_or_release: false
-            python-version: "3.10"
-          - is_main_or_release: false
-            python-version: "3.11"
-          - is_main_or_release: false
-            python-version: "3.12"
-          # Don't test on macos on 3.10 - 3.12 in PRs
-          - os: "macos-13"
-            python-version: "3.10"
-          - os: "macos-13"
-            python-version: "3.11"
-          - os: "macos-13"
-            python-version: "3.12"
-          - os: "macos-14"
-            python-version: "3.10"
-          - os: "macos-14"
-            python-version: "3.11"
-          - os: "macos-14"
-            python-version: "3.12"
-          - os: "macos-15"
-            python-version: "3.10"
-          - os: "macos-15"
-            python-version: "3.11"
-          - os: "macos-15"
-            python-version: "3.12"
-
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "macos-13", "macos-14", "macos-15"]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         is_main_or_release:
           - ${{ contains(github.ref, 'main') || startsWith(github.ref, 'refs/tags')}}
         exclude:

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,9 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Deprecate python 3.10 support (:pr:`150`)
+* Add python 3.14 to CI testing matrix (:pr:`150`)
+* Test more comprehensively in pull requests (:pr:`150`)
 * Depend on arcae ``>= 0.5.1, < 0.6.0`` (:pr:`149`)
 
 0.5.1 (06-03-2026)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ testing = [
     "pytest>=8.0.0",
     "dask>=2024.5.0",
     "distributed>=2024.5.0",
-    "zarr>=3.0.0",
+    "zarr>=2.18.3, <3.0.0",
     "platformdirs>=4.3.8",
     "xradio>=1.1.2; python_version >= '3.11' and python_version < '3.14'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ testing = [
     "pytest>=8.0.0",
     "dask>=2024.5.0",
     "distributed>=2024.5.0",
-    "zarr>=2.18.3, <3.0.0",
+    "zarr>=3.0.0",
     "platformdirs>=4.3.8",
     "xradio>=1.1.2; python_version >= '3.11' and python_version < '3.14'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.5.1"
 description = "xarray MSv4 views over MSv2 Measurement Sets"
 authors = [{name = "Simon Perkins", email = "simon.perkins@gmail.com"}]
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "xarray>=2025.0",
     "cacheout>=0.16.0",


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

This PR

- deprecates python 3.10 support
- adds python 3.14 support to the test matrix
- tests more comprehensively across the test matrix

<!-- blank -->

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--150.org.readthedocs.build/en/150/

<!-- readthedocs-preview xarray-ms end -->