### PR TITLE
Handle duplicate antenna names

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Handle duplicate antenna name (:pr:`151`)
 * Deprecate python 3.10 support (:pr:`150`)
 * Add python 3.14 to CI testing matrix (:pr:`150`)
 * Test more comprehensively in pull requests (:pr:`150`)

--- a/tests/test_antenna.py
+++ b/tests/test_antenna.py
@@ -4,6 +4,8 @@ import pytest
 import xarray
 from arcae.lib.arrow_tables import Table, ms_descriptor
 
+from xarray_ms.errors import DuplicateAntennaNameWarning
+
 NANTENNA = 6
 
 
@@ -138,3 +140,52 @@ def test_antenna_feed_join(simmed_ms, auto_corrs):
   npt.assert_array_equal(
     p1["antenna_xds"].antenna_name, np.array(["ANTENNA-0", "ANTENNA-2"], dtype=object)
   )
+
+
+@pytest.mark.parametrize(
+  "simmed_ms",
+  [{"name": "dup.ms", "nantenna": 3, "auto_corrs": True}],
+  indirect=True,
+)
+def test_duplicate_antenna_names(simmed_ms):
+  """When ANTENNA::NAME contains duplicates, names are made unique and a
+  warning is emitted.  The names in antenna_xds and the baseline coordinate
+  must be consistent with each other."""
+
+  # Overwrite ANTENNA::NAME so that antenna 0 and antenna 1 share a name.
+  with Table.from_filename(f"{simmed_ms}::ANTENNA") as T:
+    T.putcol("NAME", np.asarray(["SAME", "SAME", "OTHER"]))
+
+  with pytest.warns(DuplicateAntennaNameWarning, match="SAME"):
+    dt = xarray.open_datatree(simmed_ms, auto_corrs=True).load()
+
+  partition = dt[list(dt.children)[0]]
+  antenna_xds = partition["antenna_xds"]
+
+  # All antenna_name coordinate values must be unique
+  ant_names = antenna_xds.antenna_name.values.tolist()
+  assert len(ant_names) == len(set(ant_names)), "antenna_name coordinate has duplicates"
+
+  # Duplicated base names get -N suffixes; unique names are unchanged
+  assert "SAME-1" in ant_names
+  assert "SAME-2" in ant_names
+  assert "OTHER" in ant_names
+
+  # Every baseline antenna name must appear in antenna_xds.antenna_name
+  ant_name_set = set(ant_names)
+  assert set(partition.baseline_antenna1_name.values.tolist()) <= ant_name_set
+  assert set(partition.baseline_antenna2_name.values.tolist()) <= ant_name_set
+
+
+@pytest.mark.parametrize(
+  "simmed_ms",
+  [{"name": "nodup.ms", "nantenna": 3, "auto_corrs": True}],
+  indirect=True,
+)
+def test_unique_antenna_names_no_warning(simmed_ms):
+  """When all antenna names are already unique no warning should be emitted."""
+  import warnings
+
+  with warnings.catch_warnings():
+    warnings.simplefilter("error", DuplicateAntennaNameWarning)
+    xarray.open_datatree(simmed_ms, auto_corrs=True).load()

--- a/tests/test_antenna.py
+++ b/tests/test_antenna.py
@@ -163,7 +163,7 @@ def test_duplicate_antenna_names(simmed_ms):
   antenna_xds = partition["antenna_xds"]
 
   # All antenna_name coordinate values must be unique
-  ant_names = antenna_xds.antenna_name.values.tolist()
+  ant_names = antenna_xds.antenna_name.values
   assert len(ant_names) == len(set(ant_names)), "antenna_name coordinate has duplicates"
 
   # Duplicated base names get -N suffixes; unique names are unchanged
@@ -171,10 +171,18 @@ def test_duplicate_antenna_names(simmed_ms):
   assert "SAME-2" in ant_names
   assert "OTHER" in ant_names
 
-  # Every baseline antenna name must appear in antenna_xds.antenna_name
-  ant_name_set = set(ant_names)
-  assert set(partition.baseline_antenna1_name.values.tolist()) <= ant_name_set
-  assert set(partition.baseline_antenna2_name.values.tolist()) <= ant_name_set
+  # correlated dataset baseline_antenna{i}_name maps
+  # appropriately to the antenna dataset antenna names.
+  concat_ant_names = np.concatenate(
+    [partition.baseline_antenna1_name, partition.baseline_antenna2_name]
+  )
+  unique_ant_names, inv = np.unique(concat_ant_names, return_inverse=True)
+  _, lookup = np.where(unique_ant_names[:, None] == ant_names[None, :])
+  ant1 = lookup[inv[: len(inv) // 2]]
+  ant2 = lookup[inv[len(inv) // 2 :]]
+
+  np.testing.assert_array_equal(partition.baseline_antenna1_name, ant_names[ant1])
+  np.testing.assert_array_equal(partition.baseline_antenna2_name, ant_names[ant2])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_table_utils.py
+++ b/tests/test_table_utils.py
@@ -1,0 +1,89 @@
+import warnings
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from xarray_ms.backend.msv2.table_utils import unique_antenna_names
+from xarray_ms.errors import DuplicateAntennaNameWarning
+
+
+def test_all_unique_no_change():
+  names = np.array(["A", "B", "C"])
+  result = unique_antenna_names(names)
+  npt.assert_array_equal(result, names)
+
+
+def test_all_unique_no_warning():
+  names = np.array(["A", "B", "C"])
+  with warnings.catch_warnings():
+    warnings.simplefilter("error", DuplicateAntennaNameWarning)
+    unique_antenna_names(names)  # should not raise
+
+
+def test_two_duplicates():
+  names = np.array(["A", "A", "B"])
+  with pytest.warns(DuplicateAntennaNameWarning):
+    result = unique_antenna_names(names)
+  npt.assert_array_equal(result, ["A-1", "A-2", "B"])
+
+
+def test_triple_duplicate():
+  names = np.array(["A", "A", "A"])
+  with pytest.warns(DuplicateAntennaNameWarning):
+    result = unique_antenna_names(names)
+  npt.assert_array_equal(result, ["A-1", "A-2", "A-3"])
+
+
+def test_non_contiguous_duplicates():
+  names = np.array(["A", "B", "A", "C", "A"])
+  with pytest.warns(DuplicateAntennaNameWarning):
+    result = unique_antenna_names(names)
+  npt.assert_array_equal(result, ["A-1", "B", "A-2", "C", "A-3"])
+
+
+def test_unique_name_unchanged_when_mixed():
+  names = np.array(["X", "Y", "X"])
+  with pytest.warns(DuplicateAntennaNameWarning):
+    result = unique_antenna_names(names)
+  npt.assert_array_equal(result, ["X-1", "Y", "X-2"])
+
+
+def test_underscore_in_base_name():
+  """Dash separator avoids collision with names already containing underscores."""
+  names = np.array(["ANTENNA_1", "ANTENNA_1"])
+  with pytest.warns(DuplicateAntennaNameWarning):
+    result = unique_antenna_names(names)
+  npt.assert_array_equal(result, ["ANTENNA_1-1", "ANTENNA_1-2"])
+
+
+def test_empty_array():
+  names = np.array([], dtype=str)
+  result = unique_antenna_names(names)
+  npt.assert_array_equal(result, [])
+
+
+def test_single_element():
+  names = np.array(["A"])
+  result = unique_antenna_names(names)
+  npt.assert_array_equal(result, ["A"])
+
+
+def test_warning_raised_on_duplicates():
+  names = np.array(["A", "A", "B"])
+  with pytest.warns(DuplicateAntennaNameWarning, match="Duplicate antenna names"):
+    unique_antenna_names(names)
+
+
+def test_warning_lists_duplicate_names():
+  names = np.array(["FOO", "BAR", "FOO"])
+  with pytest.warns(DuplicateAntennaNameWarning, match="FOO"):
+    unique_antenna_names(names)
+
+
+def test_result_is_always_unique():
+  """Output names must all be distinct regardless of input."""
+  names = np.array(["A", "A", "B", "B", "C"])
+  with pytest.warns(DuplicateAntennaNameWarning):
+    result = unique_antenna_names(names)
+  assert len(set(result.tolist())) == len(result)

--- a/xarray_ms/backend/msv2/factories/antenna.py
+++ b/xarray_ms/backend/msv2/factories/antenna.py
@@ -4,6 +4,7 @@ from xarray import Dataset, Variable
 from xarray_ms.backend.msv2.factories.core import DatasetFactory
 from xarray_ms.backend.msv2.imputation import maybe_impute_observation_table
 from xarray_ms.backend.msv2.measures_encoders import MSv2CoderFactory
+from xarray_ms.backend.msv2.table_utils import unique_antenna_names
 from xarray_ms.errors import InvalidMeasurementSet
 
 RELOCATABLE_ARRAY = {"ALMA", "VLA", "NOEMA", "EVLA"}
@@ -53,7 +54,10 @@ class AntennaFactory(DatasetFactory):
       )
 
     ant_coder_factory = MSv2CoderFactory.from_arrow_table(filtered_ants)
-    antenna_names = filtered_ants["NAME"].to_numpy().astype(str)
+    # Deduplicate against the full ANTENNA table so suffix assignments are
+    # consistent with those produced in the correlated dataset factory.
+    all_ant_names = unique_antenna_names(ants["NAME"].to_numpy().astype(str))
+    antenna_names = all_ant_names[feed_ant_id[mask]]
     telescope_names = np.asarray([telescope_name] * len(antenna_names), dtype=str)
     position = pac.list_flatten(filtered_ants["POSITION"]).to_numpy().reshape(-1, 3)
     diameter = filtered_ants["DISH_DIAMETER"].to_numpy()

--- a/xarray_ms/backend/msv2/factories/correlated.py
+++ b/xarray_ms/backend/msv2/factories/correlated.py
@@ -26,6 +26,7 @@ from xarray_ms.backend.msv2.measures_encoders import (
   VisibilityCoder,
 )
 from xarray_ms.backend.msv2.structure import MSv2StructureFactory, PartitionKeyT
+from xarray_ms.backend.msv2.table_utils import unique_antenna_names
 from xarray_ms.casa_types import ColumnDesc, Polarisations
 from xarray_ms.errors import (
   ColumnShapeImputationWarning,
@@ -266,7 +267,7 @@ class CorrelatedFactory(DatasetFactory):
     assert (partition.nbl,) == ant1.shape
 
     antenna = self._subtable_factories["ANTENNA"].instance
-    ant_names = antenna["NAME"].to_numpy().astype(str)
+    ant_names = unique_antenna_names(antenna["NAME"].to_numpy().astype(str))
     ant1_names = ant_names[ant1]
     ant2_names = ant_names[ant2]
 

--- a/xarray_ms/backend/msv2/table_utils.py
+++ b/xarray_ms/backend/msv2/table_utils.py
@@ -17,8 +17,7 @@ def unique_antenna_names(names: np.ndarray) -> np.ndarray:
   emitted when any renaming is performed.
   """
   unique, counts = np.unique(names, return_counts=True)
-  duplicates = set(unique[counts > 1].tolist())
-  if not duplicates:
+  if not (duplicates := set(unique[counts > 1].tolist())):
     return names
 
   warnings.warn(
@@ -28,13 +27,15 @@ def unique_antenna_names(names: np.ndarray) -> np.ndarray:
     DuplicateAntennaNameWarning,
     stacklevel=2,
   )
-  result = names.copy()
+  # Build as a Python list to avoid numpy fixed-width string truncation,
+  # then convert back to an array with a wide enough dtype.
+  result = names.tolist()
   counters: Dict[str, int] = {}
-  for i, name in enumerate(names.tolist()):
+  for i, name in enumerate(result):
     if name in duplicates:
       counters[name] = counters.get(name, 0) + 1
       result[i] = f"{name}-{counters[name]}"
-  return result
+  return np.array(result, dtype=str)
 
 
 def extract_table_desc(table: pa.Table) -> Dict[str, Any]:

--- a/xarray_ms/backend/msv2/table_utils.py
+++ b/xarray_ms/backend/msv2/table_utils.py
@@ -1,7 +1,40 @@
 import json
+import warnings
 from typing import Any, Dict
 
+import numpy as np
 import pyarrow as pa
+
+from xarray_ms.errors import DuplicateAntennaNameWarning
+
+
+def unique_antenna_names(names: np.ndarray) -> np.ndarray:
+  """Return antenna names with duplicates made unique by appending -N suffixes.
+
+  All occurrences of a duplicated name are renamed: the first gets ``-1``,
+  the second ``-2``, and so on.  Names that are already unique are left
+  unchanged.  A :class:`~xarray_ms.errors.DuplicateAntennaNameWarning` is
+  emitted when any renaming is performed.
+  """
+  unique, counts = np.unique(names, return_counts=True)
+  duplicates = set(unique[counts > 1].tolist())
+  if not duplicates:
+    return names
+
+  warnings.warn(
+    f"Duplicate antenna names detected in the ANTENNA table: "
+    f"{sorted(duplicates)}. "
+    f"A numeric suffix will be appended to make names unique.",
+    DuplicateAntennaNameWarning,
+    stacklevel=2,
+  )
+  result = names.copy()
+  counters: Dict[str, int] = {}
+  for i, name in enumerate(names.tolist()):
+    if name in duplicates:
+      counters[name] = counters.get(name, 0) + 1
+      result[i] = f"{name}-{counters[name]}"
+  return result
 
 
 def extract_table_desc(table: pa.Table) -> Dict[str, Any]:

--- a/xarray_ms/errors.py
+++ b/xarray_ms/errors.py
@@ -30,6 +30,11 @@ class ImputedMetadataWarning(MissingMetadataWarning):
   if the original metadata is missing"""
 
 
+class DuplicateAntennaNameWarning(UserWarning):
+  """Warning raised when duplicate antenna names are found in the ANTENNA table
+  and are made unique by appending a numeric suffix"""
+
+
 class FrameConversionWarning(UserWarning):
   """Warning raised if there's no defined conversion from a CASA
   to astropy reference frame"""


### PR DESCRIPTION
<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

While duplicate antenna names are unlikely in real data, MSv2 allows them in the ANTENNA subtable.
This is problematic for MSv4 as antenna names are used as coordinates an need to uniquely identify antenna.
This PR ensures that antenna names are unique by changing them to a `NAME1-{i}`, `NAME2-{j}` pattern where `NAME1` and `NAME2` are duplicate antenna names and `i` and `j` are unique monotically increasing sequences starting at 1.

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--151.org.readthedocs.build/en/151/

<!-- readthedocs-preview xarray-ms end -->