### PR TITLE
Revert: Allow unsupported arguments in entrypoint methods (#154)

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Revert: Allow unsupported arguments in entrypoint methods (#154) (:pr:`155`)
+
 0.5.4 (20-05-2026)
 ------------------
 * Allow unsupported arguments in entrypoint methods (:pr:`154`)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -7,7 +7,6 @@ import xarray.testing as xt
 from numpy.testing import assert_array_equal
 
 from xarray_ms.backend.msv2.entrypoint import MSv2EntryPoint
-from xarray_ms.errors import IgnoredArgument
 from xarray_ms.testing.utils import id_string, prune_datetime_structures
 
 
@@ -238,14 +237,3 @@ def test_open_datatree_chunking(simmed_ms):
   }
 
   assert ncdt.identical(prune_datetime_structures(dt))
-
-
-@pytest.mark.parametrize(
-  "simmed_ms",
-  [{"name": "ignored_kwargs.ms"}],
-  indirect=True,
-)
-def test_ignored_kwargs_warning(simmed_ms):
-  with pytest.warns(IgnoredArgument, match="unsupported_kwarg"):
-    dt = xarray.open_datatree(simmed_ms, unsupported_kwarg=True)
-  assert isinstance(dt, xarray.DataTree)

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -25,11 +25,7 @@ from xarray_ms.backend.msv2.structure import (
   MSv2Structure,
   MSv2StructureFactory,
 )
-from xarray_ms.errors import (
-  FrameConversionWarning,
-  IgnoredArgument,
-  InvalidPartitionKey,
-)
+from xarray_ms.errors import FrameConversionWarning, InvalidPartitionKey
 from xarray_ms.msv4_types import CORRELATED_DATASET_TYPES
 from xarray_ms.multiton import Multiton
 from xarray_ms.utils import format_docstring
@@ -456,13 +452,6 @@ class MSv2EntryPoint(BackendEntrypoint):
     """Create a dictionary of :class:`~xarray.Dataset` presenting an MSv4 view
     over a partition of a MSv2 CASA Measurement Set"""
 
-    if kwargs:
-      warnings.warn(
-        f"xarray-ms does not support the following arguments and will ignore them: "
-        f"{sorted(kwargs)}",
-        IgnoredArgument,
-      )
-
     if isinstance(filename_or_obj, os.PathLike):
       ms = str(filename_or_obj)
     elif isinstance(filename_or_obj, str):
@@ -503,6 +492,7 @@ class MSv2EntryPoint(BackendEntrypoint):
         ninstances=store_args.ninstances,
         epoch=store_args.epoch,
         structure_factory=store_args.structure_factory,
+        **kwargs,
       )
 
       antenna_factory = AntennaFactory(

--- a/xarray_ms/errors.py
+++ b/xarray_ms/errors.py
@@ -1,7 +1,3 @@
-class IgnoredArgument(UserWarning):
-  """Issued when keyword arguments are passed that this backend does not support."""
-
-
 class IrregularGridWarning(UserWarning):
   """Base Warning for irregular grids"""
 


### PR DESCRIPTION
- See https://github.com/ratt-ru/xarray-kat/pull/62 for the general reasoning surrounding this revert

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--155.org.readthedocs.build/en/155/

<!-- readthedocs-preview xarray-ms end -->