### PR TITLE
Remove *kwargs from MSv2EntryPoint methods

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Remove ``*kwargs`` from ``MSv2EntryPoint`` methods (:pr:`156`)
 * Revert: Allow unsupported arguments in entrypoint methods (#154) (:pr:`155`)
 
 0.5.4 (20-05-2026)

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -310,7 +310,6 @@ class MSv2EntryPoint(BackendEntrypoint):
     auto_corrs: bool = False,
     ninstances: int = 8,
     epoch: str | None = None,
-    **kwargs,
   ) -> DataTree:
     """Create a :class:`~xarray.core.datatree.DataTree` presenting an MSv4 view
     over multiple partitions of a MSv2 CASA Measurement Set.
@@ -366,7 +365,6 @@ class MSv2EntryPoint(BackendEntrypoint):
       auto_corrs=auto_corrs,
       ninstances=ninstances,
       epoch=epoch,
-      **kwargs,
     )
 
     dt = DataTree.from_dict(groups_dict)
@@ -447,7 +445,6 @@ class MSv2EntryPoint(BackendEntrypoint):
     ninstances: int = 8,
     epoch: str | None = None,
     structure_factory: MSv2StructureFactory | None = None,
-    **kwargs,
   ) -> Dict[str, Dataset]:
     """Create a dictionary of :class:`~xarray.Dataset` presenting an MSv4 view
     over a partition of a MSv2 CASA Measurement Set"""
@@ -492,7 +489,6 @@ class MSv2EntryPoint(BackendEntrypoint):
         ninstances=store_args.ninstances,
         epoch=store_args.epoch,
         structure_factory=store_args.structure_factory,
-        **kwargs,
       )
 
       antenna_factory = AntennaFactory(


### PR DESCRIPTION
- See discussion in https://github.com/ratt-ru/xarray-kat/pull/62 for the reasoning behind this PR

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--156.org.readthedocs.build/en/156/

<!-- readthedocs-preview xarray-ms end -->