### PR TITLE
Introduce `pytest != 9.1.0` version restriction

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Introduce ``pytest != 9.1.0`` version restriction (:pr:`162`)
+
 0.5.5 (12-06-2026)
 ------------------
 * Upgrade to arcae 0.5.2 (:pr:`161`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 
 [dependency-groups]
 test = [
-    "pytest>=8.0.0",
+    "pytest>=8.0.0,!=9.1.0",
     "dask>=2024.5.0",
     "distributed>=2024.5.0",
     "zarr>=2.18.3, <3.0.0",


### PR DESCRIPTION
9.1.0 introduced the following regression

- https://github.com/pytest-dev/pytest/issues/14591

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--162.org.readthedocs.build/en/162/

<!-- readthedocs-preview xarray-ms end -->