### PR TITLE
Resolve file:// URIs to local filesystem paths

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Resolve ``file://`` URIs to local filesystem paths (:issue:`157`)
 * Introduce ``pytest != 9.1.0`` version restriction (:pr:`162`)
 
 0.5.5 (12-06-2026)

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
-* Resolve ``file://`` URIs to local filesystem paths (:issue:`157`)
+* Resolve ``file://`` URIs to local filesystem paths (:pr:`164`)
 * Introduce ``pytest != 9.1.0`` version restriction (:pr:`162`)
 
 0.5.5 (12-06-2026)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,6 +1,23 @@
 import xarray
 
 
+def test_gh157(simmed_ms):
+  """Tests that #157 is fixed
+
+  ``file://`` URIs are resolved to local filesystem paths.
+
+  https://github.com/ratt-ru/xarray-ms/issues/157
+  """
+  reference = xarray.open_datatree(simmed_ms)
+
+  for uri in (f"file://{simmed_ms}", f"file://localhost{simmed_ms}"):
+    dt = xarray.open_datatree(uri)
+    assert dt.children.keys() == reference.children.keys()
+
+    ds = xarray.open_dataset(uri)
+    assert ds.sizes == reference[next(iter(reference.children))].ds.sizes
+
+
 def test_gh116(simmed_ms):
   """Tests that #116 is fixed
 

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -5,10 +5,13 @@ import warnings
 from datetime import datetime, timezone
 from importlib.metadata import version as importlib_version
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 import xarray
 from xarray.backends import BackendEntrypoint
-from xarray.backends.common import AbstractWritableDataStore, _normalize_path
+from xarray.backends.common import AbstractWritableDataStore
+from xarray.backends.common import _normalize_path as _xr_normalize_path
 from xarray.backends.store import StoreBackendEntrypoint
 from xarray.core.dataset import Dataset
 from xarray.core.datatree import DataTree
@@ -73,6 +76,26 @@ def promote_chunks(
       return_chunks.update((k, v) for k in rkeys)
 
   return return_chunks
+
+
+def _normalize_path(
+  filename_or_obj: str | os.PathLike[Any] | BufferedIOBase | AbstractDataStore,
+):
+  """Normalize the input path, additionally converting ``file://`` URIs
+  into local filesystem paths.
+
+  CASA Measurement Sets are local directories, so a ``file://`` URI
+  is resolved to the path it refers to before being handed to the backend.
+  """
+  if isinstance(filename_or_obj, str):
+    parsed = urlparse(filename_or_obj)
+    if parsed.scheme == "file":
+      # An empty or "localhost" netloc refers to the local machine.
+      # A non-empty netloc denotes a host (e.g. a Windows UNC path).
+      netloc = "" if parsed.netloc == "localhost" else parsed.netloc
+      filename_or_obj = url2pathname(netloc + parsed.path)
+
+  return _xr_normalize_path(filename_or_obj)
 
 
 class MSv2Store(AbstractWritableDataStore):
@@ -453,10 +476,8 @@ class MSv2EntryPoint(BackendEntrypoint):
     """Create a dictionary of :class:`~xarray.Dataset` presenting an MSv4 view
     over a partition of a MSv2 CASA Measurement Set"""
 
-    if isinstance(filename_or_obj, os.PathLike):
-      ms = str(filename_or_obj)
-    elif isinstance(filename_or_obj, str):
-      ms = filename_or_obj
+    if isinstance(filename_or_obj, (str, os.PathLike)):
+      ms = _normalize_path(filename_or_obj)
     else:
       raise ValueError("Measurement Set paths must be strings")
 


### PR DESCRIPTION
## Problem

Opening a Measurement Set with a `file://` URI failed (#157) with a misleading error:

```
ValueError: found the following matches with the input file in xarray's IO backends: ['netcdf4']...
```

### Root cause

xarray's `_normalize_path` treats anything matching `^scheme://` as a remote URI (including `file://`) and passes it through **unchanged**. As a result:

1. `guess_can_open` looked for `table.dat` under the literal `file:///...` path, `os.path.exists` reported it missing, and the MSv2 backend declined to handle the MS.
2. xarray fell back to other backends (netcdf4), producing the confusing error above.

## Fix

Add a local `_normalize_path` wrapper that resolves `file://` URIs to local filesystem paths (via `urllib`) before delegating to xarray's normalizer. CASA Measurement Sets are always local directories, so this is the correct semantic. It handles:

- `file:///path/to.ms` (empty netloc)
- `file://localhost/path/to.ms` (localhost netloc)
- a non-empty host netloc is preserved (Windows UNC paths)

`guess_can_open` and `open_dataset` already route through the `_normalize_path` name, so they pick up the new behaviour automatically. `open_groups_as_dict` (used by `open_datatree`) is tidied to run its path handling through the same helper.

## Testing

- Added regression test `test_gh157` covering `file://` and `file://localhost` URIs for both `open_datatree` and `open_dataset`.
- `tests/test_github.py`, `tests/test_backend.py`, `tests/test_read.py` pass locally.
- Pre-commit hooks (ruff, ruff format, mypy) pass.

Fixes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--164.org.readthedocs.build/en/164/

<!-- readthedocs-preview xarray-ms end -->