### PR TITLE
Default epoch to "" to avoid re-initialisation of MSv2Structures on every xarray.open_datatree call

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 =========
 
+0.5.7 (Unreleased)
+------------------
+* Default epoch to "" to avoid re-initialisation of MSv2Structures
+  on every xarray.open_datatree call (:pr:`167`)
+
 0.5.6 (26-06-2026)
 ------------------
 * Resolve ``file://`` URIs to local filesystem paths (:pr:`164`)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -153,3 +153,40 @@ def test_msv2_structure_release(simmed_ms):
     assert ncached_structures() > 0
 
   assert ncached_structures() == 0
+
+
+def test_epoch_cache_stability(simmed_ms):
+  """Sequential open→pickle→close→load tasks must not ratchet MSv2Structures.
+
+  Each task simulates the pfb-imaging distribution pattern: the driver opens
+  the datatree, pickles a sub-dataset for dispatch, then closes. The worker
+  unpickles and loads without calling close(). The driver's close() releases
+  its Multiton entries; the worker's load() re-accesses the same
+  structure_factory key and rebuilds one MSv2Structure.
+
+  With a per-open unique epoch (the old behaviour), each task's payload carries
+  a distinct Multiton key, so every worker load adds a fresh MSv2Structure to
+  the cache: after N tasks, N structures are cached and each sits there until
+  its 300s inactivity TTL expires — the source of the pfb-imaging RSS ratchet.
+
+  With a fixed default epoch, all tasks share one key and the cache stays at 1.
+  """
+
+  def ncached_structures():
+    return sum(
+      isinstance(obj, MSv2Structure)
+      for obj, _, _, _ in Multiton._INSTANCE_CACHE.values()
+    )
+
+  NTASKS = 5
+
+  for _ in range(NTASKS):
+    # driver: open, pickle a node's dataset for dispatch, then close
+    dt = xarray.open_datatree(simmed_ms, engine="xarray-ms:msv2")
+    node = next(iter(dt.children.values()))
+    payload = pickle.dumps(node.ds)
+    dt.close()
+    # worker: load without ever calling close()
+    pickle.loads(payload).load()
+
+  assert ncached_structures() == 1

--- a/xarray_ms/backend/msv2/entrypoint_utils.py
+++ b/xarray_ms/backend/msv2/entrypoint_utils.py
@@ -1,6 +1,5 @@
 import os.path
 from typing import Dict, List, Literal
-from uuid import uuid4
 
 import pyarrow as pa
 from arcae.lib.arrow_tables import Table
@@ -96,7 +95,7 @@ class CommonStoreArgs:
     self.ms = ms
     self.ninstances = ninstances
     self.auto_corrs = auto_corrs
-    self.epoch = epoch or uuid4().hex[:8]
+    self.epoch = epoch if epoch is not None else ""
     self.partition_schema = partition_schema or DEFAULT_PARTITION_COLUMNS
     self.preferred_chunks = preferred_chunks or {}
     self.ms_factory = ms_factory or Multiton(


### PR DESCRIPTION
This was desired behaviour but caused problems in multi-process cases where internal MSv2Structures were opened multiple times.

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-ms/issues/new/choose

Development setup information is available at the following url:
https://xarray-ms.readthedocs.io/en/latest/install.html#development
-->

Thanks for contributing to xarray-ms.

We would appreciate it if you could add:

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.


<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--167.org.readthedocs.build/en/167/

<!-- readthedocs-preview xarray-ms end -->