### PR TITLE
Upgrade to arcae 0.5.4; add driver/driver_kwargs and deprecate ninstances

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -11,10 +11,10 @@ X.Y.Z (unreleased)
   ``open_datatree``. ``driver_kwargs`` defaults to ``{"cache_size": 256}``,
   bounding the caches of the main table and all subtables (including large
   subtables such as ``POINTING``), with per-table overrides under the reserved
-  ``"tables"`` key
+  ``"table_overrides"`` key (:pr:`167`)
 * Deprecate the ``ninstances`` argument in favour of
-  ``driver_kwargs={"tables": {"MAIN": {"ninstances": N}}}``. It is still
-  respected for now but will not be in a future release
+  ``driver_kwargs={"table_overrides": {"MAIN": {"ninstances": N}}}``. It is still
+  respected for now but will not be in a future release (:pr:`167`)
 
 0.5.7 (21-07-2026)
 ------------------

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,19 @@
 Changelog
 =========
 
+X.Y.Z (unreleased)
+------------------
+* Upgrade to arcae 0.5.4, which bounds the previously unbounded tiled
+  storage-manager caches (:pr:`167`)
+* Add ``driver`` and ``driver_kwargs`` arguments to ``open_dataset`` and
+  ``open_datatree``. ``driver_kwargs`` defaults to ``{"cache_size": 256}``,
+  bounding the caches of the main table and all subtables (including large
+  subtables such as ``POINTING``), with per-table overrides under the reserved
+  ``"tables"`` key
+* Deprecate the ``ninstances`` argument in favour of
+  ``driver_kwargs={"tables": {"MAIN": {"ninstances": N}}}``. It is still
+  respected for now but will not be in a future release
+
 0.5.7 (21-07-2026)
 ------------------
 * Default epoch to "" to avoid re-initialisation of MSv2Structures

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,15 +6,15 @@ Changelog
 X.Y.Z (unreleased)
 ------------------
 * Upgrade to arcae 0.5.4, which bounds the previously unbounded tiled
-  storage-manager caches (:pr:`167`)
+  storage-manager caches (:pr:`169`)
 * Add ``driver`` and ``driver_kwargs`` arguments to ``open_dataset`` and
   ``open_datatree``. ``driver_kwargs`` defaults to ``{"cache_size": 256}``,
   bounding the caches of the main table and all subtables (including large
   subtables such as ``POINTING``), with per-table overrides under the reserved
-  ``"table_overrides"`` key (:pr:`167`)
+  ``"table_overrides"`` key (:pr:`169`)
 * Deprecate the ``ninstances`` argument in favour of
   ``driver_kwargs={"table_overrides": {"MAIN": {"ninstances": N}}}``. It is still
-  respected for now but will not be in a future release (:pr:`167`)
+  respected for now but will not be in a future release (:pr:`169`)
 
 0.5.7 (21-07-2026)
 ------------------

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -126,21 +126,21 @@ The backend driver caches Measurement Set data in memory. By default,
 ``xarray-ms`` bounds these tiled storage-manager caches to 256 MiB per table
 via the ``driver_kwargs`` argument. The same kwargs apply to the main table and
 all subtables, but per-table overrides can be specified under the reserved
-``"tables"`` key. This is useful for large subtables such as ``POINTING``:
+``"table_overrides"`` key. This is useful for large subtables such as ``POINTING``:
 
 .. ipython:: python
 
   dt = xarray.open_datatree(ms, partition_schema=["FIELD_ID"],
     driver_kwargs={
       "cache_size": 256,                    # applied to every table
-      "tables": {
+      "table_overrides": {
         "MAIN": {"ninstances": 4},          # main table only
         "POINTING": {"cache_size": 512},    # a large subtable
       },
     })
 
 .. note:: The ``ninstances`` argument is deprecated. Specify it via
-  ``driver_kwargs={"tables": {"MAIN": {"ninstances": N}}}`` instead.
+  ``driver_kwargs={"table_overrides": {"MAIN": {"ninstances": N}}}`` instead.
 
 
 Writing a DataTree to Zarr

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -119,6 +119,30 @@ for more information.
   dt
 
 
+Bounding driver memory
+----------------------
+
+The backend driver caches Measurement Set data in memory. By default,
+``xarray-ms`` bounds these tiled storage-manager caches to 256 MiB per table
+via the ``driver_kwargs`` argument. The same kwargs apply to the main table and
+all subtables, but per-table overrides can be specified under the reserved
+``"tables"`` key. This is useful for large subtables such as ``POINTING``:
+
+.. ipython:: python
+
+  dt = xarray.open_datatree(ms, partition_schema=["FIELD_ID"],
+    driver_kwargs={
+      "cache_size": 256,                    # applied to every table
+      "tables": {
+        "MAIN": {"ninstances": 4},          # main table only
+        "POINTING": {"cache_size": 512},    # a large subtable
+      },
+    })
+
+.. note:: The ``ninstances`` argument is deprecated. Specify it via
+  ``driver_kwargs={"tables": {"MAIN": {"ninstances": N}}}`` instead.
+
+
 Writing a DataTree to Zarr
 --------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
     "xarray>=2025.0",
-    "arcae>=0.5.2, < 0.6.0",
+    "arcae>=0.5.4, < 0.6.0",
     "typing-extensions>=4.12.2",
     "rarg-python-patterns>=0.0.3",
 ]

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,0 +1,121 @@
+"""Tests for the ``driver`` / ``driver_kwargs`` arguments and the
+deprecation of ``ninstances``."""
+
+import pytest
+import xarray
+
+from xarray_ms.backend.msv2.entrypoint import MSv2EntryPoint
+from xarray_ms.backend.msv2.entrypoint_utils import (
+  DEFAULT_MAIN_NINSTANCES,
+  CommonStoreArgs,
+  resolve_driver_kwargs,
+  table_driver_kwargs,
+)
+
+# Positional layout of Table.from_filename after Multiton normalisation:
+# (filename, ninstances, readonly, lockoptions, cache_size)
+_NINSTANCES = 1
+_CACHE_SIZE = 4
+
+
+def test_resolve_driver_kwargs_default():
+  """The default materialises a bounded cache and warns about nothing."""
+  assert resolve_driver_kwargs("arcae", None) == {"cache_size": 256}
+
+
+def test_resolve_driver_kwargs_unsupported_driver():
+  with pytest.raises(ValueError, match="Unsupported driver 'bogus'"):
+    resolve_driver_kwargs("bogus", None)
+
+
+@pytest.mark.filterwarnings("ignore:.*?'ninstances' argument is deprecated")
+def test_resolve_driver_kwargs_does_not_mutate_input():
+  """The returned dictionary is a deep copy safe to mutate downstream."""
+  user = {"cache_size": 256, "tables": {"POINTING": {"cache_size": 512}}}
+  resolved = resolve_driver_kwargs("arcae", user, ninstances=4)
+  resolved["tables"]["POINTING"]["cache_size"] = 0
+  assert user == {"cache_size": 256, "tables": {"POINTING": {"cache_size": 512}}}
+
+
+def test_resolve_driver_kwargs_ninstances_deprecated():
+  """A supplied ninstances warns and is folded into the main table scope."""
+  with pytest.warns(DeprecationWarning, match="'ninstances' argument is deprecated"):
+    resolved = resolve_driver_kwargs("arcae", None, ninstances=4)
+  assert resolved["tables"]["MAIN"]["ninstances"] == 4
+
+
+def test_resolve_driver_kwargs_explicit_main_beats_deprecated():
+  """An explicit main-table override wins over the deprecated ninstances."""
+  dk = {"tables": {"MAIN": {"ninstances": 2}}}
+  with pytest.warns(DeprecationWarning):
+    resolved = resolve_driver_kwargs("arcae", dk, ninstances=8)
+  assert resolved["tables"]["MAIN"]["ninstances"] == 2
+
+
+def test_table_driver_kwargs_main_defaults_ninstances():
+  assert table_driver_kwargs({"cache_size": 256}, "MAIN") == {
+    "cache_size": 256,
+    "ninstances": DEFAULT_MAIN_NINSTANCES,
+  }
+
+
+def test_table_driver_kwargs_flat_applies_to_subtable():
+  """Flat kwargs apply uniformly; subtables get no implicit ninstances."""
+  assert table_driver_kwargs({"cache_size": 256}, "POINTING") == {"cache_size": 256}
+
+
+def test_table_driver_kwargs_per_table_override():
+  dk = {"cache_size": 256, "tables": {"POINTING": {"cache_size": 512}}}
+  assert table_driver_kwargs(dk, "POINTING") == {"cache_size": 512}
+  assert table_driver_kwargs(dk, "SPECTRAL_WINDOW") == {"cache_size": 256}
+
+
+def test_common_store_args_default_cache(simmed_ms):
+  """Default driver_kwargs bound the main table and every subtable."""
+  store_args = CommonStoreArgs(simmed_ms)
+
+  assert store_args.ms_factory._args[_NINSTANCES] == DEFAULT_MAIN_NINSTANCES
+  assert store_args.ms_factory._args[_CACHE_SIZE] == 256
+
+  for factory in store_args.subtable_factories.values():
+    assert factory._kw == {"cache_size": 256}
+
+
+def test_common_store_args_pointing_override(simmed_ms):
+  """A per-subtable override reaches only that subtable."""
+  driver_kwargs = {"cache_size": 256, "tables": {"POINTING": {"cache_size": 512}}}
+  store_args = CommonStoreArgs(simmed_ms, driver_kwargs=driver_kwargs)
+
+  assert store_args.subtable_factories["POINTING"]._kw == {"cache_size": 512}
+  assert store_args.subtable_factories["SPECTRAL_WINDOW"]._kw == {"cache_size": 256}
+
+
+@pytest.mark.filterwarnings("ignore:.*?'ninstances' argument is deprecated")
+def test_common_store_args_deprecated_ninstances_main_only(simmed_ms):
+  """The deprecated ninstances affects the main table, not subtables."""
+  driver_kwargs = resolve_driver_kwargs("arcae", None, ninstances=1)
+  store_args = CommonStoreArgs(simmed_ms, driver_kwargs=driver_kwargs)
+
+  assert store_args.ms_factory._args[_NINSTANCES] == 1
+  # Subtables always default to a single instance
+  assert "ninstances" not in store_args.subtable_factories["POINTING"]._kw
+
+
+def test_open_dataset_ninstances_deprecation(simmed_ms):
+  with pytest.warns(DeprecationWarning, match="'ninstances' argument is deprecated"):
+    xarray.open_dataset(simmed_ms, ninstances=4)
+
+
+def test_open_dataset_unsupported_driver(simmed_ms):
+  with pytest.raises(ValueError, match="Unsupported driver 'bogus'"):
+    MSv2EntryPoint().open_dataset(simmed_ms, driver="bogus")
+
+
+def test_open_datatree_ninstances_deprecation_warns_once(simmed_ms, recwarn):
+  """The deprecation is raised exactly once despite the re-entrant open path."""
+  xarray.open_datatree(simmed_ms, ninstances=4)
+  deprecations = [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+  ninstances_warnings = [
+    w for w in deprecations if "'ninstances' argument is deprecated" in str(w.message)
+  ]
+  assert len(ninstances_warnings) == 1

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -31,25 +31,28 @@ def test_resolve_driver_kwargs_unsupported_driver():
 @pytest.mark.filterwarnings("ignore:.*?'ninstances' argument is deprecated")
 def test_resolve_driver_kwargs_does_not_mutate_input():
   """The returned dictionary is a deep copy safe to mutate downstream."""
-  user = {"cache_size": 256, "tables": {"POINTING": {"cache_size": 512}}}
+  user = {"cache_size": 256, "table_overrides": {"POINTING": {"cache_size": 512}}}
   resolved = resolve_driver_kwargs("arcae", user, ninstances=4)
-  resolved["tables"]["POINTING"]["cache_size"] = 0
-  assert user == {"cache_size": 256, "tables": {"POINTING": {"cache_size": 512}}}
+  resolved["table_overrides"]["POINTING"]["cache_size"] = 0
+  assert user == {
+    "cache_size": 256,
+    "table_overrides": {"POINTING": {"cache_size": 512}},
+  }
 
 
 def test_resolve_driver_kwargs_ninstances_deprecated():
   """A supplied ninstances warns and is folded into the main table scope."""
   with pytest.warns(DeprecationWarning, match="'ninstances' argument is deprecated"):
     resolved = resolve_driver_kwargs("arcae", None, ninstances=4)
-  assert resolved["tables"]["MAIN"]["ninstances"] == 4
+  assert resolved["table_overrides"]["MAIN"]["ninstances"] == 4
 
 
 def test_resolve_driver_kwargs_explicit_main_beats_deprecated():
   """An explicit main-table override wins over the deprecated ninstances."""
-  dk = {"tables": {"MAIN": {"ninstances": 2}}}
+  dk = {"table_overrides": {"MAIN": {"ninstances": 2}}}
   with pytest.warns(DeprecationWarning):
     resolved = resolve_driver_kwargs("arcae", dk, ninstances=8)
-  assert resolved["tables"]["MAIN"]["ninstances"] == 2
+  assert resolved["table_overrides"]["MAIN"]["ninstances"] == 2
 
 
 def test_table_driver_kwargs_main_defaults_ninstances():
@@ -65,7 +68,7 @@ def test_table_driver_kwargs_flat_applies_to_subtable():
 
 
 def test_table_driver_kwargs_per_table_override():
-  dk = {"cache_size": 256, "tables": {"POINTING": {"cache_size": 512}}}
+  dk = {"cache_size": 256, "table_overrides": {"POINTING": {"cache_size": 512}}}
   assert table_driver_kwargs(dk, "POINTING") == {"cache_size": 512}
   assert table_driver_kwargs(dk, "SPECTRAL_WINDOW") == {"cache_size": 256}
 
@@ -83,7 +86,10 @@ def test_common_store_args_default_cache(simmed_ms):
 
 def test_common_store_args_pointing_override(simmed_ms):
   """A per-subtable override reaches only that subtable."""
-  driver_kwargs = {"cache_size": 256, "tables": {"POINTING": {"cache_size": 512}}}
+  driver_kwargs = {
+    "cache_size": 256,
+    "table_overrides": {"POINTING": {"cache_size": 512}},
+  }
   store_args = CommonStoreArgs(simmed_ms, driver_kwargs=driver_kwargs)
 
   assert store_args.subtable_factories["POINTING"]._kw == {"cache_size": 512}

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -320,14 +320,14 @@ class MSv2EntryPoint(BackendEntrypoint):
         Defaults to :code:`{{"cache_size": 256}}`, bounding the tiled
         storage-manager caches (in MiB) of every table. These kwargs apply
         uniformly to the main table and all subtables. Per-table overrides may
-        be specified under the reserved :code:`"tables"` key, addressing the
+        be specified under the reserved :code:`"table_overrides"` key, addressing the
         main table as :code:`"MAIN"` and subtables by name, e.g.
 
         .. code-block:: python
 
           {{
             "cache_size": 256,                    # applied to every table
-            "tables": {{
+            "table_overrides": {{
               "MAIN": {{"ninstances": 4}},          # main table only
               "POINTING": {{"cache_size": 512}},    # a large subtable
             }},
@@ -337,7 +337,7 @@ class MSv2EntryPoint(BackendEntrypoint):
 
         .. deprecated::
           ``ninstances`` will not be respected in a future release. Pass it via
-          :code:`driver_kwargs={{"tables": {{"MAIN": {{"ninstances": N}}}}}}`
+          :code:`driver_kwargs={{"table_overrides": {{"MAIN": {{"ninstances": N}}}}}}`
           instead.
 
       epoch: A unique string identifying the creation of this Dataset.
@@ -424,14 +424,14 @@ class MSv2EntryPoint(BackendEntrypoint):
         Defaults to :code:`{{"cache_size": 256}}`, bounding the tiled
         storage-manager caches (in MiB) of every table. These kwargs apply
         uniformly to the main table and all subtables. Per-table overrides may
-        be specified under the reserved :code:`"tables"` key, addressing the
+        be specified under the reserved :code:`"table_overrides"` key, addressing the
         main table as :code:`"MAIN"` and subtables by name, e.g.
 
         .. code-block:: python
 
           {{
             "cache_size": 256,                    # applied to every table
-            "tables": {{
+            "table_overrides": {{
               "MAIN": {{"ninstances": 4}},          # main table only
               "POINTING": {{"cache_size": 512}},    # a large subtable
             }},
@@ -441,7 +441,7 @@ class MSv2EntryPoint(BackendEntrypoint):
 
         .. deprecated::
           ``ninstances`` will not be respected in a future release. Pass it via
-          :code:`driver_kwargs={{"tables": {{"MAIN": {{"ninstances": N}}}}}}`
+          :code:`driver_kwargs={{"table_overrides": {{"MAIN": {{"ninstances": N}}}}}}`
           instead.
 
       epoch: A string uniquely identifying this Dataset.

--- a/xarray_ms/backend/msv2/entrypoint.py
+++ b/xarray_ms/backend/msv2/entrypoint.py
@@ -4,7 +4,7 @@ import os
 import warnings
 from datetime import datetime, timezone
 from importlib.metadata import version as importlib_version
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Mapping
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -17,7 +17,10 @@ from xarray.core.dataset import Dataset
 from xarray.core.datatree import DataTree
 from xarray.core.utils import try_read_magic_number_from_file_or_path
 
-from xarray_ms.backend.msv2.entrypoint_utils import CommonStoreArgs
+from xarray_ms.backend.msv2.entrypoint_utils import (
+  CommonStoreArgs,
+  resolve_driver_kwargs,
+)
 from xarray_ms.backend.msv2.factories import (
   AntennaFactory,
   CorrelatedFactory,
@@ -109,7 +112,8 @@ class MSv2Store(AbstractWritableDataStore):
     "_partition_key",
     "_preferred_chunks",
     "_auto_corrs",
-    "_ninstances",
+    "_driver",
+    "_driver_kwargs",
     "_epoch",
   )
 
@@ -120,7 +124,8 @@ class MSv2Store(AbstractWritableDataStore):
   _partition_key: PartitionKeyT
   _preferred_chunks: Dict[str, int]
   _autocorrs: bool
-  _ninstances: int
+  _driver: str
+  _driver_kwargs: Dict[str, Any]
   _epoch: str
 
   def __init__(
@@ -132,7 +137,8 @@ class MSv2Store(AbstractWritableDataStore):
     partition_key: PartitionKeyT,
     preferred_chunks: Dict[str, int],
     auto_corrs: bool,
-    ninstances: int,
+    driver: str,
+    driver_kwargs: Dict[str, Any],
     epoch: str,
   ):
     self._table_factory = table_factory
@@ -142,7 +148,8 @@ class MSv2Store(AbstractWritableDataStore):
     self._partition_key = partition_key
     self._preferred_chunks = preferred_chunks
     self._auto_corrs = auto_corrs
-    self._ninstances = ninstances
+    self._driver = driver
+    self._driver_kwargs = driver_kwargs
     self._epoch = epoch
 
   @classmethod
@@ -154,7 +161,8 @@ class MSv2Store(AbstractWritableDataStore):
     partition_key: PartitionKeyT | None = None,
     preferred_chunks: Dict[str, int] | None = None,
     auto_corrs: bool = False,
-    ninstances: int = 1,
+    driver: str = "arcae",
+    driver_kwargs: Dict[str, Any] | None = None,
     epoch: str | None = None,
     structure_factory: MSv2StructureFactory | None = None,
   ):
@@ -163,7 +171,8 @@ class MSv2Store(AbstractWritableDataStore):
 
     store_args = CommonStoreArgs(
       ms,
-      ninstances,
+      driver,
+      driver_kwargs,
       auto_corrs,
       epoch,
       partition_schema,
@@ -195,7 +204,8 @@ class MSv2Store(AbstractWritableDataStore):
       partition_key=partition_key,
       preferred_chunks=store_args.preferred_chunks,
       auto_corrs=store_args.auto_corrs,
-      ninstances=store_args.ninstances,
+      driver=store_args.driver,
+      driver_kwargs=store_args.driver_kwargs,
       epoch=store_args.epoch,
     )
 
@@ -246,6 +256,8 @@ class MSv2EntryPoint(BackendEntrypoint):
     "partition_key",
     "preferred_chunks",
     "auto_corrs",
+    "driver",
+    "driver_kwargs",
     "ninstances",
     "epoch",
     "structure_factory",
@@ -282,7 +294,9 @@ class MSv2EntryPoint(BackendEntrypoint):
     partition_key: PartitionKeyT | None = None,
     preferred_chunks: Dict[str, int] | None = None,
     auto_corrs: bool = False,
-    ninstances: int = 8,
+    driver: Literal["arcae"] = "arcae",
+    driver_kwargs: Dict[str, Any] | None = None,
+    ninstances: int | None = None,
     epoch: str | None = None,
     structure_factory: MSv2StructureFactory | None = None,
   ) -> Dataset:
@@ -300,7 +314,32 @@ class MSv2EntryPoint(BackendEntrypoint):
         If :code:`None`, the first partition will be opened.
       preferred_chunks: The preferred chunks for each partition.
       auto_corrs: Include/Exclude auto-correlations.
+      driver: The backend driver used to access the Measurement Set.
+        Only :code:`"arcae"` is currently supported.
+      driver_kwargs: Keyword arguments passed to the backend driver.
+        Defaults to :code:`{{"cache_size": 256}}`, bounding the tiled
+        storage-manager caches (in MiB) of every table. These kwargs apply
+        uniformly to the main table and all subtables. Per-table overrides may
+        be specified under the reserved :code:`"tables"` key, addressing the
+        main table as :code:`"MAIN"` and subtables by name, e.g.
+
+        .. code-block:: python
+
+          {{
+            "cache_size": 256,                    # applied to every table
+            "tables": {{
+              "MAIN": {{"ninstances": 4}},          # main table only
+              "POINTING": {{"cache_size": 512}},    # a large subtable
+            }},
+          }}
+
       ninstances: The number of Measurement Set instances to open for parallel I/O.
+
+        .. deprecated::
+          ``ninstances`` will not be respected in a future release. Pass it via
+          :code:`driver_kwargs={{"tables": {{"MAIN": {{"ninstances": N}}}}}}`
+          instead.
+
       epoch: A unique string identifying the creation of this Dataset.
         This should not normally need to be set by the user
       structure_factory: A factory for creating MSv2Structure objects.
@@ -311,6 +350,7 @@ class MSv2EntryPoint(BackendEntrypoint):
       partition specified by :code:`partition_schema` and :code:`partition_key`.
     """
     filename_or_obj = _normalize_path(filename_or_obj)
+    driver_kwargs = resolve_driver_kwargs(driver, driver_kwargs, ninstances)
 
     store = MSv2Store.open(
       filename_or_obj,
@@ -319,7 +359,8 @@ class MSv2EntryPoint(BackendEntrypoint):
       partition_key=partition_key,
       preferred_chunks=preferred_chunks,
       auto_corrs=auto_corrs,
-      ninstances=ninstances,
+      driver=driver,
+      driver_kwargs=driver_kwargs,
       epoch=epoch,
       structure_factory=structure_factory,
     )
@@ -335,7 +376,9 @@ class MSv2EntryPoint(BackendEntrypoint):
     drop_variables: str | Iterable[str] | None = None,
     partition_schema: List[str] | None = None,
     auto_corrs: bool = False,
-    ninstances: int = 8,
+    driver: Literal["arcae"] = "arcae",
+    driver_kwargs: Dict[str, Any] | None = None,
+    ninstances: int | None = None,
     epoch: str | None = None,
   ) -> DataTree:
     """Create a :class:`~xarray.core.datatree.DataTree` presenting an MSv4 view
@@ -375,7 +418,32 @@ class MSv2EntryPoint(BackendEntrypoint):
         Defaults to :code:`{DEFAULT_PARTITION_COLUMNS}`.
         See :ref:`partitioning-guide` for more further information.
       auto_corrs: Include/Exclude auto-correlations.
+      driver: The backend driver used to access the Measurement Set.
+        Only :code:`"arcae"` is currently supported.
+      driver_kwargs: Keyword arguments passed to the backend driver.
+        Defaults to :code:`{{"cache_size": 256}}`, bounding the tiled
+        storage-manager caches (in MiB) of every table. These kwargs apply
+        uniformly to the main table and all subtables. Per-table overrides may
+        be specified under the reserved :code:`"tables"` key, addressing the
+        main table as :code:`"MAIN"` and subtables by name, e.g.
+
+        .. code-block:: python
+
+          {{
+            "cache_size": 256,                    # applied to every table
+            "tables": {{
+              "MAIN": {{"ninstances": 4}},          # main table only
+              "POINTING": {{"cache_size": 512}},    # a large subtable
+            }},
+          }}
+
       ninstances: The number of Measurement Set instances to open for parallel I/O.
+
+        .. deprecated::
+          ``ninstances`` will not be respected in a future release. Pass it via
+          :code:`driver_kwargs={{"tables": {{"MAIN": {{"ninstances": N}}}}}}`
+          instead.
+
       epoch: A string uniquely identifying this Dataset.
         This should not normally be set by the user
 
@@ -384,13 +452,15 @@ class MSv2EntryPoint(BackendEntrypoint):
 
     .. _preferred_chunk_sizes: https://docs.xarray.dev/en/stable/internals/how-to-add-new-backend.html#preferred-chunk-sizes
     """
+    driver_kwargs = resolve_driver_kwargs(driver, driver_kwargs, ninstances)
     groups_dict = self.open_groups_as_dict(
       filename_or_obj,
       drop_variables=drop_variables,
       partition_schema=partition_schema,
       preferred_chunks=preferred_chunks,
       auto_corrs=auto_corrs,
-      ninstances=ninstances,
+      driver=driver,
+      driver_kwargs=driver_kwargs,
       epoch=epoch,
     )
 
@@ -469,7 +539,9 @@ class MSv2EntryPoint(BackendEntrypoint):
     partition_schema: List[str] | None = None,
     preferred_chunks: Dict[str, int] | None = None,
     auto_corrs: bool = False,
-    ninstances: int = 8,
+    driver: Literal["arcae"] = "arcae",
+    driver_kwargs: Dict[str, Any] | None = None,
+    ninstances: int | None = None,
     epoch: str | None = None,
     structure_factory: MSv2StructureFactory | None = None,
   ) -> Dict[str, Dataset]:
@@ -481,9 +553,12 @@ class MSv2EntryPoint(BackendEntrypoint):
     else:
       raise ValueError("Measurement Set paths must be strings")
 
+    driver_kwargs = resolve_driver_kwargs(driver, driver_kwargs, ninstances)
+
     store_args = CommonStoreArgs(
       ms,
-      ninstances,
+      driver,
+      driver_kwargs,
       auto_corrs,
       epoch,
       partition_schema,
@@ -511,7 +586,8 @@ class MSv2EntryPoint(BackendEntrypoint):
         if isinstance(pchunks, Mapping)
         else pchunks,
         auto_corrs=store_args.auto_corrs,
-        ninstances=store_args.ninstances,
+        driver=store_args.driver,
+        driver_kwargs=store_args.driver_kwargs,
         epoch=store_args.epoch,
         structure_factory=store_args.structure_factory,
       )

--- a/xarray_ms/backend/msv2/entrypoint_utils.py
+++ b/xarray_ms/backend/msv2/entrypoint_utils.py
@@ -21,7 +21,9 @@ SUPPORTED_DRIVERS = ("arcae",)
 DEFAULT_DRIVER_KWARGS: Dict[str, Any] = {"cache_size": 256}
 #: Default number of instances opened for the main table.
 DEFAULT_MAIN_NINSTANCES = 8
-#: Reserved key in ``driver_kwargs["tables"]`` addressing the main table.
+#: Reserved key in ``driver_kwargs`` holding per-table override dictionaries.
+TABLE_OVERRIDES = "table_overrides"
+#: Reserved key in ``driver_kwargs[TABLE_OVERRIDES]`` addressing the main table.
 MAIN_TABLE = "MAIN"
 
 # These tables should always be present on an MS
@@ -67,13 +69,13 @@ def resolve_driver_kwargs(
     warnings.warn(
       "The 'ninstances' argument is deprecated and will not be respected in "
       "a future release. Pass driver-specific options via "
-      "driver_kwargs={'tables': {'MAIN': {'ninstances': N}}} instead.",
+      "driver_kwargs={'table_overrides': {'MAIN': {'ninstances': N}}} instead.",
       DeprecationWarning,
       stacklevel=2,
     )
     # Historically ninstances only affected the main table. An explicit
     # driver_kwargs override for the main table takes precedence.
-    dk.setdefault("tables", {}).setdefault(MAIN_TABLE, {}).setdefault(
+    dk.setdefault(TABLE_OVERRIDES, {}).setdefault(MAIN_TABLE, {}).setdefault(
       "ninstances", ninstances
     )
 
@@ -85,11 +87,11 @@ def table_driver_kwargs(driver_kwargs: Dict[str, Any], name: str) -> Dict[str, A
 
   ``name`` is :data:`MAIN_TABLE` for the main table, or a subtable name (e.g.
   ``"POINTING"``). Flat kwargs apply to every table; per-table overrides under
-  the reserved ``"tables"`` key take precedence. The main table defaults to
-  :data:`DEFAULT_MAIN_NINSTANCES` instances when unspecified.
+  the reserved :data:`TABLE_OVERRIDES` key take precedence. The main table
+  defaults to :data:`DEFAULT_MAIN_NINSTANCES` instances when unspecified.
   """
-  base = {k: v for k, v in driver_kwargs.items() if k != "tables"}
-  resolved = {**base, **driver_kwargs.get("tables", {}).get(name, {})}
+  base = {k: v for k, v in driver_kwargs.items() if k != TABLE_OVERRIDES}
+  resolved = {**base, **driver_kwargs.get(TABLE_OVERRIDES, {}).get(name, {})}
   if name == MAIN_TABLE:
     resolved.setdefault("ninstances", DEFAULT_MAIN_NINSTANCES)
   return resolved

--- a/xarray_ms/backend/msv2/entrypoint_utils.py
+++ b/xarray_ms/backend/msv2/entrypoint_utils.py
@@ -1,5 +1,7 @@
 import os.path
-from typing import Dict, List, Literal
+import warnings
+from copy import deepcopy
+from typing import Any, Dict, List, Literal
 
 import pyarrow as pa
 from arcae.lib.arrow_tables import Table
@@ -12,6 +14,15 @@ from xarray_ms.backend.msv2.structure import (
   MSv2StructureFactory,
   SubtableFactory,
 )
+
+#: Backend drivers currently supported by xarray-ms.
+SUPPORTED_DRIVERS = ("arcae",)
+#: Default keyword arguments passed to the backend driver.
+DEFAULT_DRIVER_KWARGS: Dict[str, Any] = {"cache_size": 256}
+#: Default number of instances opened for the main table.
+DEFAULT_MAIN_NINSTANCES = 8
+#: Reserved key in ``driver_kwargs["tables"]`` addressing the main table.
+MAIN_TABLE = "MAIN"
 
 # These tables should always be present on an MS
 DEFAULT_SUBTABLES = [
@@ -34,12 +45,66 @@ EXTRA_SUBTABLES = [
 ]
 
 
+def resolve_driver_kwargs(
+  driver: str,
+  driver_kwargs: Dict[str, Any] | None,
+  ninstances: int | None = None,
+) -> Dict[str, Any]:
+  """Validate ``driver`` and materialise the effective ``driver_kwargs``.
+
+  The deprecated ``ninstances`` argument, when supplied, is folded into the
+  main table's per-table overrides and a :class:`DeprecationWarning` is raised.
+  The returned dictionary is a deep copy that is safe to mutate downstream.
+  """
+  if driver not in SUPPORTED_DRIVERS:
+    raise ValueError(
+      f"Unsupported driver {driver!r}. Supported drivers: {SUPPORTED_DRIVERS}"
+    )
+
+  dk = deepcopy(DEFAULT_DRIVER_KWARGS if driver_kwargs is None else driver_kwargs)
+
+  if ninstances is not None:
+    warnings.warn(
+      "The 'ninstances' argument is deprecated and will not be respected in "
+      "a future release. Pass driver-specific options via "
+      "driver_kwargs={'tables': {'MAIN': {'ninstances': N}}} instead.",
+      DeprecationWarning,
+      stacklevel=2,
+    )
+    # Historically ninstances only affected the main table. An explicit
+    # driver_kwargs override for the main table takes precedence.
+    dk.setdefault("tables", {}).setdefault(MAIN_TABLE, {}).setdefault(
+      "ninstances", ninstances
+    )
+
+  return dk
+
+
+def table_driver_kwargs(driver_kwargs: Dict[str, Any], name: str) -> Dict[str, Any]:
+  """Resolve the effective driver kwargs for the table identified by ``name``.
+
+  ``name`` is :data:`MAIN_TABLE` for the main table, or a subtable name (e.g.
+  ``"POINTING"``). Flat kwargs apply to every table; per-table overrides under
+  the reserved ``"tables"`` key take precedence. The main table defaults to
+  :data:`DEFAULT_MAIN_NINSTANCES` instances when unspecified.
+  """
+  base = {k: v for k, v in driver_kwargs.items() if k != "tables"}
+  resolved = {**base, **driver_kwargs.get("tables", {}).get(name, {})}
+  if name == MAIN_TABLE:
+    resolved.setdefault("ninstances", DEFAULT_MAIN_NINSTANCES)
+  return resolved
+
+
 def subtable_factory(
-  name: str, on_missing: Literal["raise", "empty_table"] = "empty_table"
+  name: str,
+  on_missing: Literal["raise", "empty_table"] = "empty_table",
+  **driver_kwargs: Any,
 ) -> pa.Table:
+  # Subtables are read once via to_arrow(); a single instance is sufficient.
+  driver_kwargs.setdefault("ninstances", 1)
   try:
     return Table.from_filename(
-      name, ninstances=1, readonly=True, lockoptions="nolock"
+      name, readonly=True, lockoptions="nolock", **driver_kwargs
     ).to_arrow()
   except pa.lib.ArrowInvalid as e:
     e_str = str(e)
@@ -56,7 +121,8 @@ class CommonStoreArgs:
   values from multiple locations"""
 
   ms: str
-  ninstances: int
+  driver: str
+  driver_kwargs: Dict[str, Any]
   auto_corrs: bool
   epoch: str
   partition_schema: List[str]
@@ -67,7 +133,8 @@ class CommonStoreArgs:
 
   __slots__ = (
     "ms",
-    "ninstances",
+    "driver",
+    "driver_kwargs",
     "auto_corrs",
     "epoch",
     "partition_schema",
@@ -80,7 +147,8 @@ class CommonStoreArgs:
   def __init__(
     self,
     ms: str,
-    ninstances: int = 1,
+    driver: str = "arcae",
+    driver_kwargs: Dict[str, Any] | None = None,
     auto_corrs: bool = True,
     epoch: str | None = None,
     partition_schema: List[str] | None = None,
@@ -93,7 +161,10 @@ class CommonStoreArgs:
       raise FileNotFoundError(f"{ms} does not exist")
 
     self.ms = ms
-    self.ninstances = ninstances
+    self.driver = driver
+    self.driver_kwargs = (
+      deepcopy(DEFAULT_DRIVER_KWARGS) if driver_kwargs is None else driver_kwargs
+    )
     self.auto_corrs = auto_corrs
     self.epoch = epoch if epoch is not None else ""
     self.partition_schema = partition_schema or DEFAULT_PARTITION_COLUMNS
@@ -101,12 +172,16 @@ class CommonStoreArgs:
     self.ms_factory = ms_factory or Multiton(
       Table.from_filename,
       self.ms,
-      ninstances=self.ninstances,
       readonly=True,
       lockoptions="nolock",
+      **table_driver_kwargs(self.driver_kwargs, MAIN_TABLE),
     )
     self.subtable_factories = subtable_factories or {
-      subtable: Multiton(subtable_factory, f"{ms}::{subtable}")
+      subtable: Multiton(
+        subtable_factory,
+        f"{ms}::{subtable}",
+        **table_driver_kwargs(self.driver_kwargs, subtable),
+      )
       for subtable in (DEFAULT_SUBTABLES + EXTRA_SUBTABLES)
     }
     self.structure_factory = structure_factory or Multiton(


### PR DESCRIPTION
## Summary

Upgrades to arcae 0.5.4 (which bounds the previously unbounded tiled storage-manager caches, [arcae PR #222](https://github.com/ratt-ru/arcae/pull/222)) and exposes that control through the xarray backend API to address the unbounded cache growth reported in #167.

- Adds `driver: Literal["arcae"] = "arcae"` and `driver_kwargs: Dict[str, Any] | None = None` to `MSv2EntryPoint.open_dataset` / `open_datatree` (and `open_groups_as_dict`).
- `driver_kwargs` defaults to `{"cache_size": 256}` and applies **uniformly to the main table and all subtables**, so large subtables such as `POINTING` are bounded by default.
- Per-table overrides are specified under the reserved `"table_overrides"` key, addressing the main table as `"MAIN"` and subtables by name:

  ```python
  driver_kwargs={
      "cache_size": 256,                    # applied to every table
      "table_overrides": {
          "MAIN": {"ninstances": 4},        # main table only
          "POINTING": {"cache_size": 512},  # a large subtable
      },
  }
  ```

- Deprecates `ninstances`: passing it now issues a `DeprecationWarning` and folds the value into the main-table scope. It is **still respected for the moment** (main table only, as historically), but will not be in a future release. An explicit `driver_kwargs["tables"]["MAIN"]["ninstances"]` takes precedence. The main-table default remains `ninstances=8`.

## Implementation notes

- `resolve_driver_kwargs()` validates the driver, deep-copies the kwargs, and folds the deprecated `ninstances` in — called once per public method so the warning fires exactly once despite the re-entrant `xarray.open_dataset` path.
- `table_driver_kwargs()` resolves flat kwargs plus per-table `"tables"` overrides; the `ninstances=8` default is injected for `MAIN` only, subtables default to a single instance.

## Tests

New `tests/test_driver.py` (14 tests): resolution/precedence, no input mutation, per-table overrides reaching the correct Multitons, deprecation warning (including warns-once through `open_datatree`), and unsupported-driver `ValueError`.

Full suite: `142 passed, 2 skipped, 5 xfailed`; pre-commit (ruff, ruff-format, mypy) passing.

## Note

The changelog entry is `X.Y.Z (unreleased)` — set the real version/date at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview xarray-ms start -->
----
📚 Documentation preview 📚: https://xarray-ms--169.org.readthedocs.build/en/169/

<!-- readthedocs-preview xarray-ms end -->